### PR TITLE
[Jed] Step 3-2: 리팩토링 & 속성 변경 동작 구현

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -21,7 +21,18 @@
 		B5E73BC827D083750016E628 /* StylerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC727D083750016E628 /* StylerView.swift */; };
 		B5E73BCC27D1340F0016E628 /* ViewMutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BCB27D1340F0016E628 /* ViewMutable.swift */; };
 		B5E73BCE27D138300016E628 /* ModelMutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BCD27D138300016E628 /* ModelMutable.swift */; };
+		B5E73BE127D1E5690016E628 /* PlaneTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BD227D1E5040016E628 /* PlaneTest.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		B5E73BDC27D1E5610016E628 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B5E73B9427CDC29D0016E628 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B5E73B9B27CDC29E0016E628;
+			remoteInfo = DrawingApp;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		B5E73B9C27CDC29E0016E628 /* DrawingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrawingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -40,6 +51,8 @@
 		B5E73BC727D083750016E628 /* StylerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylerView.swift; sourceTree = "<group>"; };
 		B5E73BCB27D1340F0016E628 /* ViewMutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMutable.swift; sourceTree = "<group>"; };
 		B5E73BCD27D138300016E628 /* ModelMutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelMutable.swift; sourceTree = "<group>"; };
+		B5E73BD227D1E5040016E628 /* PlaneTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneTest.swift; sourceTree = "<group>"; };
+		B5E73BD827D1E5610016E628 /* DrawingAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DrawingAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +64,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B5E73BD527D1E5610016E628 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -58,6 +78,7 @@
 			isa = PBXGroup;
 			children = (
 				B5E73B9E27CDC29E0016E628 /* DrawingApp */,
+				B5E73BD927D1E5610016E628 /* DrawingAppTests */,
 				B5E73B9D27CDC29E0016E628 /* Products */,
 				B5E73BB827CE01320016E628 /* Frameworks */,
 			);
@@ -67,6 +88,7 @@
 			isa = PBXGroup;
 			children = (
 				B5E73B9C27CDC29E0016E628 /* DrawingApp.app */,
+				B5E73BD827D1E5610016E628 /* DrawingAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -124,6 +146,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		B5E73BD927D1E5610016E628 /* DrawingAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				B5E73BD227D1E5040016E628 /* PlaneTest.swift */,
+			);
+			path = DrawingAppTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -144,6 +174,24 @@
 			productReference = B5E73B9C27CDC29E0016E628 /* DrawingApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		B5E73BD727D1E5610016E628 /* DrawingAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B5E73BDE27D1E5610016E628 /* Build configuration list for PBXNativeTarget "DrawingAppTests" */;
+			buildPhases = (
+				B5E73BD427D1E5610016E628 /* Sources */,
+				B5E73BD527D1E5610016E628 /* Frameworks */,
+				B5E73BD627D1E5610016E628 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B5E73BDD27D1E5610016E628 /* PBXTargetDependency */,
+			);
+			name = DrawingAppTests;
+			productName = DrawingAppTests;
+			productReference = B5E73BD827D1E5610016E628 /* DrawingAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -156,6 +204,10 @@
 				TargetAttributes = {
 					B5E73B9B27CDC29E0016E628 = {
 						CreatedOnToolsVersion = 13.2.1;
+					};
+					B5E73BD727D1E5610016E628 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = B5E73B9B27CDC29E0016E628;
 					};
 				};
 			};
@@ -173,6 +225,7 @@
 			projectRoot = "";
 			targets = (
 				B5E73B9B27CDC29E0016E628 /* DrawingApp */,
+				B5E73BD727D1E5610016E628 /* DrawingAppTests */,
 			);
 		};
 /* End PBXProject section */
@@ -185,6 +238,13 @@
 				B5E73BAC27CDC2A10016E628 /* LaunchScreen.storyboard in Resources */,
 				B5E73BA927CDC2A10016E628 /* Assets.xcassets in Resources */,
 				B5E73BA727CDC29E0016E628 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B5E73BD627D1E5610016E628 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -208,7 +268,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B5E73BD427D1E5610016E628 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B5E73BE127D1E5690016E628 /* PlaneTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		B5E73BDD27D1E5610016E628 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B5E73B9B27CDC29E0016E628 /* DrawingApp */;
+			targetProxy = B5E73BDC27D1E5610016E628 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		B5E73BA527CDC29E0016E628 /* Main.storyboard */ = {
@@ -400,6 +476,40 @@
 			};
 			name = Release;
 		};
+		B5E73BDF27D1E5610016E628 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = practice.junu0516.DrawingAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DrawingApp.app/DrawingApp";
+			};
+			name = Debug;
+		};
+		B5E73BE027D1E5610016E628 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = practice.junu0516.DrawingAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DrawingApp.app/DrawingApp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -417,6 +527,15 @@
 			buildConfigurations = (
 				B5E73BB127CDC2A10016E628 /* Debug */,
 				B5E73BB227CDC2A10016E628 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B5E73BDE27D1E5610016E628 /* Build configuration list for PBXNativeTarget "DrawingAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B5E73BDF27D1E5610016E628 /* Debug */,
+				B5E73BE027D1E5610016E628 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		B5E73BBA27CE01320016E628 /* OSLog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5E73BB927CE01320016E628 /* OSLog.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BBB27CF457B0016E628 /* Plane.swift */; };
 		B5E73BC427D082630016E628 /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC327D082630016E628 /* CanvasView.swift */; };
-		B5E73BC627D0835B0016E628 /* GeneratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC527D0835B0016E628 /* GeneratorView.swift */; };
 		B5E73BC827D083750016E628 /* StylerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC727D083750016E628 /* StylerView.swift */; };
 /* End PBXBuildFile section */
 
@@ -36,7 +35,6 @@
 		B5E73BB927CE01320016E628 /* OSLog.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OSLog.framework; path = System/Library/Frameworks/OSLog.framework; sourceTree = SDKROOT; };
 		B5E73BBB27CF457B0016E628 /* Plane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plane.swift; sourceTree = "<group>"; };
 		B5E73BC327D082630016E628 /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
-		B5E73BC527D0835B0016E628 /* GeneratorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorView.swift; sourceTree = "<group>"; };
 		B5E73BC727D083750016E628 /* StylerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -115,7 +113,6 @@
 			isa = PBXGroup;
 			children = (
 				B5E73BC327D082630016E628 /* CanvasView.swift */,
-				B5E73BC527D0835B0016E628 /* GeneratorView.swift */,
 				B5E73BC727D083750016E628 /* StylerView.swift */,
 			);
 			path = View;
@@ -192,7 +189,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B5E73BC627D0835B0016E628 /* GeneratorView.swift in Sources */,
 				B5E73BB727CDE3910016E628 /* RectangleFactory.swift in Sources */,
 				B5E73BC427D082630016E628 /* CanvasView.swift in Sources */,
 				B5E73BC827D083750016E628 /* StylerView.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BBB27CF457B0016E628 /* Plane.swift */; };
 		B5E73BC427D082630016E628 /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC327D082630016E628 /* CanvasView.swift */; };
 		B5E73BC827D083750016E628 /* StylerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC727D083750016E628 /* StylerView.swift */; };
+		B5E73BCC27D1340F0016E628 /* ViewMutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BCB27D1340F0016E628 /* ViewMutable.swift */; };
+		B5E73BCE27D138300016E628 /* ModelMutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BCD27D138300016E628 /* ModelMutable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +38,8 @@
 		B5E73BBB27CF457B0016E628 /* Plane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plane.swift; sourceTree = "<group>"; };
 		B5E73BC327D082630016E628 /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		B5E73BC727D083750016E628 /* StylerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylerView.swift; sourceTree = "<group>"; };
+		B5E73BCB27D1340F0016E628 /* ViewMutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMutable.swift; sourceTree = "<group>"; };
+		B5E73BCD27D138300016E628 /* ModelMutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelMutable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +109,8 @@
 			isa = PBXGroup;
 			children = (
 				B5E73BA327CDC29E0016E628 /* ViewController.swift */,
+				B5E73BCB27D1340F0016E628 /* ViewMutable.swift */,
+				B5E73BCD27D138300016E628 /* ModelMutable.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -191,11 +197,13 @@
 			files = (
 				B5E73BB727CDE3910016E628 /* RectangleFactory.swift in Sources */,
 				B5E73BC427D082630016E628 /* CanvasView.swift in Sources */,
+				B5E73BCC27D1340F0016E628 /* ViewMutable.swift in Sources */,
 				B5E73BC827D083750016E628 /* StylerView.swift in Sources */,
 				B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */,
 				B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */,
 				B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */,
 				B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */,
+				B5E73BCE27D138300016E628 /* ModelMutable.swift in Sources */,
 				B5E73BB527CDC2F90016E628 /* Rectangle.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		B5E73BB527CDC2F90016E628 /* Rectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BB427CDC2F90016E628 /* Rectangle.swift */; };
 		B5E73BB727CDE3910016E628 /* RectangleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BB627CDE3910016E628 /* RectangleFactory.swift */; };
 		B5E73BBA27CE01320016E628 /* OSLog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5E73BB927CE01320016E628 /* OSLog.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BBB27CF457B0016E628 /* Plane.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		B5E73BB427CDC2F90016E628 /* Rectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rectangle.swift; sourceTree = "<group>"; };
 		B5E73BB627CDE3910016E628 /* RectangleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleFactory.swift; sourceTree = "<group>"; };
 		B5E73BB927CE01320016E628 /* OSLog.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OSLog.framework; path = System/Library/Frameworks/OSLog.framework; sourceTree = SDKROOT; };
+		B5E73BBB27CF457B0016E628 /* Plane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plane.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +83,7 @@
 			children = (
 				B5E73BB427CDC2F90016E628 /* Rectangle.swift */,
 				B5E73BB627CDE3910016E628 /* RectangleFactory.swift */,
+				B5E73BBB27CF457B0016E628 /* Plane.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -168,6 +171,7 @@
 				B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */,
 				B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */,
 				B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */,
+				B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */,
 				B5E73BB527CDC2F90016E628 /* Rectangle.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B5A777B427D3909A0055E311 /* RectangleFoundDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A777B327D3909A0055E311 /* RectangleFoundDelegate.swift */; };
 		B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */; };
 		B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BA127CDC29E0016E628 /* SceneDelegate.swift */; };
 		B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BA327CDC29E0016E628 /* ViewController.swift */; };
@@ -19,8 +20,8 @@
 		B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BBB27CF457B0016E628 /* Plane.swift */; };
 		B5E73BC427D082630016E628 /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC327D082630016E628 /* CanvasView.swift */; };
 		B5E73BC827D083750016E628 /* StylerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC727D083750016E628 /* StylerView.swift */; };
-		B5E73BCC27D1340F0016E628 /* ViewMutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BCB27D1340F0016E628 /* ViewMutable.swift */; };
-		B5E73BCE27D138300016E628 /* ModelMutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BCD27D138300016E628 /* ModelMutable.swift */; };
+		B5E73BCC27D1340F0016E628 /* StylerViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BCB27D1340F0016E628 /* StylerViewDelegate.swift */; };
+		B5E73BCE27D138300016E628 /* CanvasViewDeleagte.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BCD27D138300016E628 /* CanvasViewDeleagte.swift */; };
 		B5E73BE127D1E5690016E628 /* PlaneTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BD227D1E5040016E628 /* PlaneTest.swift */; };
 /* End PBXBuildFile section */
 
@@ -35,6 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B5A777B327D3909A0055E311 /* RectangleFoundDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleFoundDelegate.swift; sourceTree = "<group>"; };
 		B5E73B9C27CDC29E0016E628 /* DrawingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrawingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B5E73BA127CDC29E0016E628 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -49,8 +51,8 @@
 		B5E73BBB27CF457B0016E628 /* Plane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plane.swift; sourceTree = "<group>"; };
 		B5E73BC327D082630016E628 /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		B5E73BC727D083750016E628 /* StylerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylerView.swift; sourceTree = "<group>"; };
-		B5E73BCB27D1340F0016E628 /* ViewMutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMutable.swift; sourceTree = "<group>"; };
-		B5E73BCD27D138300016E628 /* ModelMutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelMutable.swift; sourceTree = "<group>"; };
+		B5E73BCB27D1340F0016E628 /* StylerViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylerViewDelegate.swift; sourceTree = "<group>"; };
+		B5E73BCD27D138300016E628 /* CanvasViewDeleagte.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasViewDeleagte.swift; sourceTree = "<group>"; };
 		B5E73BD227D1E5040016E628 /* PlaneTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneTest.swift; sourceTree = "<group>"; };
 		B5E73BD827D1E5610016E628 /* DrawingAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DrawingAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -115,6 +117,7 @@
 				B5E73BB427CDC2F90016E628 /* Rectangle.swift */,
 				B5E73BB627CDE3910016E628 /* RectangleFactory.swift */,
 				B5E73BBB27CF457B0016E628 /* Plane.swift */,
+				B5A777B327D3909A0055E311 /* RectangleFoundDelegate.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -131,8 +134,6 @@
 			isa = PBXGroup;
 			children = (
 				B5E73BA327CDC29E0016E628 /* ViewController.swift */,
-				B5E73BCB27D1340F0016E628 /* ViewMutable.swift */,
-				B5E73BCD27D138300016E628 /* ModelMutable.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -142,6 +143,8 @@
 			children = (
 				B5E73BC327D082630016E628 /* CanvasView.swift */,
 				B5E73BC727D083750016E628 /* StylerView.swift */,
+				B5E73BCB27D1340F0016E628 /* StylerViewDelegate.swift */,
+				B5E73BCD27D138300016E628 /* CanvasViewDeleagte.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -257,13 +260,14 @@
 			files = (
 				B5E73BB727CDE3910016E628 /* RectangleFactory.swift in Sources */,
 				B5E73BC427D082630016E628 /* CanvasView.swift in Sources */,
-				B5E73BCC27D1340F0016E628 /* ViewMutable.swift in Sources */,
+				B5E73BCC27D1340F0016E628 /* StylerViewDelegate.swift in Sources */,
 				B5E73BC827D083750016E628 /* StylerView.swift in Sources */,
 				B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */,
+				B5A777B427D3909A0055E311 /* RectangleFoundDelegate.swift in Sources */,
 				B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */,
 				B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */,
 				B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */,
-				B5E73BCE27D138300016E628 /* ModelMutable.swift in Sources */,
+				B5E73BCE27D138300016E628 /* CanvasViewDeleagte.swift in Sources */,
 				B5E73BB527CDC2F90016E628 /* Rectangle.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B5A777B427D3909A0055E311 /* RectangleFoundDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A777B327D3909A0055E311 /* RectangleFoundDelegate.swift */; };
+		B5A777B427D3909A0055E311 /* PlaneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A777B327D3909A0055E311 /* PlaneDelegate.swift */; };
 		B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */; };
 		B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BA127CDC29E0016E628 /* SceneDelegate.swift */; };
 		B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BA327CDC29E0016E628 /* ViewController.swift */; };
@@ -36,7 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		B5A777B327D3909A0055E311 /* RectangleFoundDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleFoundDelegate.swift; sourceTree = "<group>"; };
+		B5A777B327D3909A0055E311 /* PlaneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneDelegate.swift; sourceTree = "<group>"; };
 		B5E73B9C27CDC29E0016E628 /* DrawingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrawingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B5E73BA127CDC29E0016E628 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -117,7 +117,7 @@
 				B5E73BB427CDC2F90016E628 /* Rectangle.swift */,
 				B5E73BB627CDE3910016E628 /* RectangleFactory.swift */,
 				B5E73BBB27CF457B0016E628 /* Plane.swift */,
-				B5A777B327D3909A0055E311 /* RectangleFoundDelegate.swift */,
+				B5A777B327D3909A0055E311 /* PlaneDelegate.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -263,7 +263,7 @@
 				B5E73BCC27D1340F0016E628 /* StylerViewDelegate.swift in Sources */,
 				B5E73BC827D083750016E628 /* StylerView.swift in Sources */,
 				B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */,
-				B5A777B427D3909A0055E311 /* RectangleFoundDelegate.swift in Sources */,
+				B5A777B427D3909A0055E311 /* PlaneDelegate.swift in Sources */,
 				B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */,
 				B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */,
 				B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		B5E73BB727CDE3910016E628 /* RectangleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BB627CDE3910016E628 /* RectangleFactory.swift */; };
 		B5E73BBA27CE01320016E628 /* OSLog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5E73BB927CE01320016E628 /* OSLog.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BBB27CF457B0016E628 /* Plane.swift */; };
+		B5E73BC427D082630016E628 /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC327D082630016E628 /* CanvasView.swift */; };
+		B5E73BC627D0835B0016E628 /* GeneratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC527D0835B0016E628 /* GeneratorView.swift */; };
+		B5E73BC827D083750016E628 /* StylerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BC727D083750016E628 /* StylerView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +35,9 @@
 		B5E73BB627CDE3910016E628 /* RectangleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleFactory.swift; sourceTree = "<group>"; };
 		B5E73BB927CE01320016E628 /* OSLog.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OSLog.framework; path = System/Library/Frameworks/OSLog.framework; sourceTree = SDKROOT; };
 		B5E73BBB27CF457B0016E628 /* Plane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plane.swift; sourceTree = "<group>"; };
+		B5E73BC327D082630016E628 /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
+		B5E73BC527D0835B0016E628 /* GeneratorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorView.swift; sourceTree = "<group>"; };
+		B5E73BC727D083750016E628 /* StylerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,10 +72,11 @@
 		B5E73B9E27CDC29E0016E628 /* DrawingApp */ = {
 			isa = PBXGroup;
 			children = (
+				B5E73BC227D080DE0016E628 /* View */,
+				B5E73BBD27D07CAA0016E628 /* Controller */,
 				B5E73BB327CDC2D20016E628 /* Model */,
 				B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */,
 				B5E73BA127CDC29E0016E628 /* SceneDelegate.swift */,
-				B5E73BA327CDC29E0016E628 /* ViewController.swift */,
 				B5E73BA527CDC29E0016E628 /* Main.storyboard */,
 				B5E73BA827CDC2A10016E628 /* Assets.xcassets */,
 				B5E73BAA27CDC2A10016E628 /* LaunchScreen.storyboard */,
@@ -94,6 +101,24 @@
 				B5E73BB927CE01320016E628 /* OSLog.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B5E73BBD27D07CAA0016E628 /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				B5E73BA327CDC29E0016E628 /* ViewController.swift */,
+			);
+			path = Controller;
+			sourceTree = "<group>";
+		};
+		B5E73BC227D080DE0016E628 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				B5E73BC327D082630016E628 /* CanvasView.swift */,
+				B5E73BC527D0835B0016E628 /* GeneratorView.swift */,
+				B5E73BC727D083750016E628 /* StylerView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -167,7 +192,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5E73BC627D0835B0016E628 /* GeneratorView.swift in Sources */,
 				B5E73BB727CDE3910016E628 /* RectangleFactory.swift in Sources */,
+				B5E73BC427D082630016E628 /* CanvasView.swift in Sources */,
+				B5E73BC827D083750016E628 /* StylerView.swift in Sources */,
 				B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */,
 				B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */,
 				B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/xcshareddata/xcschemes/DrawingApp.xcscheme
+++ b/DrawingApp/DrawingApp.xcodeproj/xcshareddata/xcschemes/DrawingApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5E73B9B27CDC29E0016E628"
+               BuildableName = "DrawingApp.app"
+               BlueprintName = "DrawingApp"
+               ReferencedContainer = "container:DrawingApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B5E73B9B27CDC29E0016E628"
+            BuildableName = "DrawingApp.app"
+            BlueprintName = "DrawingApp"
+            ReferencedContainer = "container:DrawingApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B5E73B9B27CDC29E0016E628"
+            BuildableName = "DrawingApp.app"
+            BlueprintName = "DrawingApp"
+            ReferencedContainer = "container:DrawingApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DrawingApp/DrawingApp.xcodeproj/xcshareddata/xcschemes/DrawingApp.xcscheme
+++ b/DrawingApp/DrawingApp.xcodeproj/xcshareddata/xcschemes/DrawingApp.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5E73BD727D1E5610016E628"
+               BuildableName = "DrawingAppTests.xctest"
+               BlueprintName = "DrawingAppTests"
+               ReferencedContainer = "container:DrawingApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/DrawingApp/DrawingApp/Base.lproj/LaunchScreen.storyboard
+++ b/DrawingApp/DrawingApp/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,10 +13,10 @@
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -22,4 +24,9 @@
             <point key="canvasLocation" x="53" y="375"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
+++ b/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
@@ -15,23 +15,6 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="1180" height="820"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NO4-68-JR5" userLabel="StylerView" customClass="StylerView" customModule="DrawingApp">
-                                <rect key="frame" x="940" y="0.0" width="240" height="820"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemYellowColor"/>
-                            </view>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kj0-Xx-PcI" userLabel="CanvasView" customClass="CanvasView" customModule="DrawingApp">
-                                <rect key="frame" x="0.0" y="0.0" width="943" height="690"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray4Color"/>
-                            </view>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ulc-Eb-79Y" userLabel="GeneratorView" customClass="GeneratorView" customModule="DrawingApp">
-                                <rect key="frame" x="0.0" y="686" width="943" height="134"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemRedColor"/>
-                            </view>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
@@ -44,15 +27,6 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray4Color">
-            <color red="0.81960784313725488" green="0.81960784313725488" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemYellowColor">
-            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
+++ b/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
@@ -1,24 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="ipad10_9rounded" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="DrawingApp" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1180" height="820"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NO4-68-JR5" userLabel="StylerView" customClass="StylerView" customModule="DrawingApp">
+                                <rect key="frame" x="940" y="0.0" width="240" height="820"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemYellowColor"/>
+                            </view>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kj0-Xx-PcI" userLabel="CanvasView" customClass="CanvasView" customModule="DrawingApp">
+                                <rect key="frame" x="0.0" y="0.0" width="943" height="690"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemGray4Color"/>
+                            </view>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ulc-Eb-79Y" userLabel="GeneratorView" customClass="GeneratorView" customModule="DrawingApp">
+                                <rect key="frame" x="0.0" y="686" width="943" height="134"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemRedColor"/>
+                            </view>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="131.69491525423729" y="61.463414634146339"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray4Color">
+            <color red="0.81960784313725488" green="0.81960784313725488" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/DrawingApp/DrawingApp/Controller/ModelMutable.swift
+++ b/DrawingApp/DrawingApp/Controller/ModelMutable.swift
@@ -4,4 +4,5 @@ protocol ModelMutable: AnyObject{
     
     func changeRectangleModelAlpha(opacity: Int)
     func changeRectangleModelColor(rgb: [Double])
+    func clearModelSelection()
 }

--- a/DrawingApp/DrawingApp/Controller/ModelMutable.swift
+++ b/DrawingApp/DrawingApp/Controller/ModelMutable.swift
@@ -2,5 +2,5 @@ import Foundation
 
 protocol ModelMutable: AnyObject{
     
-    func changeRectangleAlpha(x: Double, y: Double, opacity: Int)
+    func changeRectangleModelAlpha(opacity: Int)
 }

--- a/DrawingApp/DrawingApp/Controller/ModelMutable.swift
+++ b/DrawingApp/DrawingApp/Controller/ModelMutable.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol ModelMutable: AnyObject{
+    
+    func changeRectangleAlpha(x: Double, y: Double, opacity: Int)
+}

--- a/DrawingApp/DrawingApp/Controller/ModelMutable.swift
+++ b/DrawingApp/DrawingApp/Controller/ModelMutable.swift
@@ -3,4 +3,5 @@ import Foundation
 protocol ModelMutable: AnyObject{
     
     func changeRectangleModelAlpha(opacity: Int)
+    func changeRectangleModelColor(rgb: [Double])
 }

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -8,15 +8,23 @@ class ViewController: UIViewController {
     private var stylerView: StylerView?
     private var rectangleFactory: RectangleFactory = RectangleFactory()
     private var plane: Plane = Plane()
+    var gestureRecognizer = UITapGestureRecognizer()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         initializeAllUIViews()
+        setGestureRecognizer()
     }
     
     private func initializeAllUIViews(){
         setCanvasView()
         setStylerView()
+    }
+    
+    private func setGestureRecognizer(){
+        guard let canvasView = self.canvasView else { return }
+        self.gestureRecognizer.delegate = self
+        canvasView.addGestureRecognizer(self.gestureRecognizer)
     }
     
     private func setCanvasView(){
@@ -62,8 +70,25 @@ class ViewController: UIViewController {
         
         plane.addRectangle(rectangle)
         canvasView.insertSubview(rectangleView, belowSubview: canvasView.generatingButton)
-        logger.debug("\(self.plane)")
     }
 
+}
+
+extension ViewController: UIGestureRecognizerDelegate{
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        
+        let tappedPoint = touch.location(in: self.canvasView)
+        guard let rectangle = self.plane[tappedPoint.x,tappedPoint.y] else { return true }
+        guard let stylerView = self.stylerView else { return true }
+        
+        let r = rectangle.backgroundColor.r
+        let g = rectangle.backgroundColor.g
+        let b = rectangle.backgroundColor.b
+        let opacity = rectangle.alpha.opacity
+        stylerView.updateRectangleInfo(r: r, g: g, b: b, opacity: opacity)
+        
+        return true
+    }
 }
 

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -4,14 +4,35 @@ import OSLog
 class ViewController: UIViewController {
     
     private var logger: Logger = Logger()
+    private var canvasView: CanvasView?
+    private var stylerView: StylerView?
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        let factory = RectangleFactory()
-        for index in 0..<4{
-            let rectangle = factory.createRenctangle()
-            logger.debug("Rectangle\(index+1) : \(rectangle)")
-        }
+        initializeAllUIViews()
     }
+    
+    private func initializeAllUIViews(){
+        setCanvasView()
+        setStylerView()
+    }
+    
+    private func setCanvasView(){
+        let frame = CGRect(x: self.view.frame.minX, y: self.view.frame.minY, width: self.view.frame.width*0.8, height: self.view.frame.height)
+        let canvasView = CanvasView(frame: frame, backGroundColor: .lightGray, buttonActionClosure: {
+            print("closure")
+        })
+        self.canvasView = canvasView
+        self.view.addSubview(canvasView)
+    }
+    
+    private func setStylerView(){
+        guard let canvasView = self.canvasView else { return }
+        let frame = CGRect(x: canvasView.frame.width, y: self.view.frame.minY, width: self.view.frame.width - canvasView.frame.width, height: self.view.frame.height)
+        let stylerView = StylerView(frame: frame, backgroundColor: .white)
+        self.stylerView = stylerView
+        self.view.addSubview(stylerView)
+    }
+
 }
 

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -6,9 +6,7 @@ class ViewController: UIViewController{
     private var logger: Logger = Logger()
     private var canvasView: CanvasView?
     private var stylerView: StylerView?
-    private var rectangleFactory: RectangleFactory = RectangleFactory()
     private var plane: Plane = Plane()
-    var gestureRecognizer = UITapGestureRecognizer()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,8 +21,9 @@ class ViewController: UIViewController{
     
     private func setGestureRecognizer(){
         guard let canvasView = self.canvasView else { return }
-        self.gestureRecognizer.delegate = self
-        canvasView.addGestureRecognizer(self.gestureRecognizer)
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.delegate = self
+        canvasView.addGestureRecognizer(gestureRecognizer)
     }
     
     private func setCanvasView(){
@@ -55,7 +54,7 @@ class ViewController: UIViewController{
     
     func drawRectangle(){
         guard let canvasView = self.canvasView else { return }
-        let rectangle = rectangleFactory.createRenctangle(maxX: canvasView.bounds.maxX - 50,
+        let rectangle = RectangleFactory.createRenctangle(maxX: canvasView.bounds.maxX - 50,
                                                           maxY: canvasView.bounds.maxY - 250,
                                                           minWidth: 150,
                                                           minHeight: 150,

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -35,7 +35,7 @@ class ViewController: UIViewController{
         let canvasView = CanvasView(frame: frame,
                                     backGroundColor: .lightGray,
                                     buttonActionClosure: self.createRectangle)
-        canvasView.viewController = self
+        canvasView.delegate = self
         self.canvasView = canvasView
         self.view.addSubview(canvasView)
     }
@@ -47,7 +47,7 @@ class ViewController: UIViewController{
                            width: self.view.frame.width - canvasView.frame.width,
                            height: self.view.frame.height)
         let stylerView = StylerView(frame: frame, backgroundColor: .white)
-        stylerView.viewController = self
+        stylerView.delegate = self
         self.stylerView = stylerView
         self.view.addSubview(stylerView)
     }
@@ -104,7 +104,7 @@ extension ViewController: UIGestureRecognizerDelegate, RectangleFoundDelegate{
     }
 }
 
-extension ViewController: ViewMutable, ModelMutable{
+extension ViewController: CanvasViewDelegate, StylerViewDelegate{
     
     func changeSelectedRecntagleViewColor(rgb: [Double]){
         guard let canvasView = self.canvasView else { return }

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController{
                            height: self.view.frame.height)
         let canvasView = CanvasView(frame: frame,
                                     backGroundColor: .lightGray,
-                                    buttonActionClosure: self.drawRectangle,
+                                    buttonActionClosure: self.createRectangle,
                                     viewController: self)
         self.canvasView = canvasView
         self.view.addSubview(canvasView)
@@ -52,7 +52,7 @@ class ViewController: UIViewController{
         self.view.addSubview(stylerView)
     }
     
-    func drawRectangle(){
+    func createRectangle(){
         guard let canvasView = self.canvasView else { return }
         let rectangle = RectangleFactory.createRenctangle(maxX: canvasView.bounds.maxX - 50,
                                                           maxY: canvasView.bounds.maxY - 250,

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -6,12 +6,19 @@ class ViewController: UIViewController{
     private var logger: Logger = Logger()
     private var canvasView: CanvasView?
     private var stylerView: StylerView?
-    private var plane: Plane = Plane()
+    private var plane: Plane?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        initializePlane()
         initializeAllUIViews()
         setGestureRecognizer()
+    }
+    
+    private func initializePlane(){
+        var plane = Plane()
+        plane.delegate = self
+        self.plane = plane
     }
     
     private func initializeAllUIViews(){
@@ -53,6 +60,7 @@ class ViewController: UIViewController{
     }
     
     func createRectangle(){
+        guard var plane = self.plane else { return }
         guard let canvasView = self.canvasView else { return }
         let rectangle = RectangleFactory.createRenctangle(maxX: canvasView.bounds.maxX - 50,
                                                           maxY: canvasView.bounds.maxY - 250,
@@ -74,14 +82,15 @@ class ViewController: UIViewController{
     }
 }
 
-extension ViewController: UIGestureRecognizerDelegate, RectangleFoundDelegate{
+extension ViewController: UIGestureRecognizerDelegate, PlaneDelegate{
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         
         let tappedPoint = touch.location(in: self.canvasView)
+        guard var plane = self.plane else { return false }
         guard let stylerView = self.stylerView else { return false }
         guard let canvasView = self.canvasView else { return false }
-        guard let rectangle = self.plane[tappedPoint.x,tappedPoint.y] else {
+        guard let rectangle = plane[tappedPoint.x,tappedPoint.y] else {
             stylerView.clearRectangleInfo()
             canvasView.cancelSelection()
             return false
@@ -94,7 +103,7 @@ extension ViewController: UIGestureRecognizerDelegate, RectangleFoundDelegate{
         let opacity = rectangle.alpha.opacity
         stylerView.updateRectangleInfo(r: r, g: g, b: b, opacity: opacity)
         canvasView.selectTappedRectangle(subView: rectangleView)
-        self.plane.selectRectangle(id: rectangle.id)
+        plane.selectRectangle(id: rectangle.id)
         
         return true
     }
@@ -120,8 +129,9 @@ extension ViewController: CanvasViewDelegate, StylerViewDelegate{
     
     func changeRectangleModelAlpha(opacity: Int) {
         var opacity = opacity
-        guard let selectedRectangleId = self.plane.selectedRectangleId else { return }
-        guard let rectangle = self.plane[selectedRectangleId] else { return }
+        guard let plane = self.plane else { return }
+        guard let selectedRectangleId = plane.selectedRectangleId else { return }
+        guard let rectangle = plane[selectedRectangleId] else { return }
         if(opacity == 10){
             opacity = opacity - 1
         }
@@ -129,12 +139,14 @@ extension ViewController: CanvasViewDelegate, StylerViewDelegate{
     }
     
     func changeRectangleModelColor(rgb: [Double]) {
-        guard let selectedRectangleId = self.plane.selectedRectangleId else { return }
-        guard let rectangle = self.plane[selectedRectangleId] else { return }
+        guard let plane = self.plane else { return }
+        guard let selectedRectangleId = plane.selectedRectangleId else { return }
+        guard let rectangle = plane[selectedRectangleId] else { return }
         rectangle.backgroundColor = Rectangle.Color(r: rgb[0]*255, g: rgb[1]*255, b: rgb[2]*255)
     }
     
     func clearModelSelection() {
-        self.plane.clearModelSelection()
+        guard var plane = self.plane else { return }
+        plane.clearModelSelection()
     }
 }

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -61,7 +61,8 @@ class ViewController: UIViewController {
                                                 alpha: CGFloat(rectangle.alpha.opacity))
         
         plane.addRectangle(rectangle)
-        canvasView.addSubview(rectangleView)
+        canvasView.insertSubview(rectangleView, belowSubview: canvasView.generatingButton)
+        logger.debug("\(self.plane)")
     }
 
 }

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -4,8 +4,8 @@ import OSLog
 class ViewController: UIViewController{
     
     private var logger: Logger = Logger()
-    private var canvasView: CanvasView?
-    private var stylerView: StylerView?
+    private weak var canvasView: CanvasView?
+    private weak var stylerView: StylerView?
     private var plane: Plane = Plane()
     
     override func viewDidLoad() {
@@ -24,6 +24,7 @@ class ViewController: UIViewController{
         let gestureRecognizer = UITapGestureRecognizer()
         gestureRecognizer.delegate = self
         canvasView.addGestureRecognizer(gestureRecognizer)
+        
     }
     
     private func setCanvasView(){
@@ -33,8 +34,8 @@ class ViewController: UIViewController{
                            height: self.view.frame.height)
         let canvasView = CanvasView(frame: frame,
                                     backGroundColor: .lightGray,
-                                    buttonActionClosure: self.createRectangle,
-                                    viewController: self)
+                                    buttonActionClosure: self.createRectangle)
+        canvasView.viewController = self
         self.canvasView = canvasView
         self.view.addSubview(canvasView)
     }
@@ -45,9 +46,8 @@ class ViewController: UIViewController{
                            y: self.view.frame.minY,
                            width: self.view.frame.width - canvasView.frame.width,
                            height: self.view.frame.height)
-        let stylerView = StylerView(frame: frame,
-                                    backgroundColor: .white,
-                                    viewController: self)
+        let stylerView = StylerView(frame: frame, backgroundColor: .white)
+        stylerView.viewController = self
         self.stylerView = stylerView
         self.view.addSubview(stylerView)
     }
@@ -74,7 +74,7 @@ class ViewController: UIViewController{
     }
 }
 
-extension ViewController: UIGestureRecognizerDelegate{
+extension ViewController: UIGestureRecognizerDelegate, RectangleFoundDelegate{
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         
@@ -97,6 +97,10 @@ extension ViewController: UIGestureRecognizerDelegate{
         self.plane.selectRectangle(id: rectangle.id)
         
         return true
+    }
+    
+    func rectangleModelFound() {
+        
     }
 }
 

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import OSLog
 
-class ViewController: UIViewController {
+class ViewController: UIViewController{
     
     private var logger: Logger = Logger()
     private var canvasView: CanvasView?
@@ -34,7 +34,8 @@ class ViewController: UIViewController {
                            height: self.view.frame.height)
         let canvasView = CanvasView(frame: frame,
                                     backGroundColor: .lightGray,
-                                    buttonActionClosure: self.drawRectangle)
+                                    buttonActionClosure: self.drawRectangle,
+                                    viewController: self)
         self.canvasView = canvasView
         self.view.addSubview(canvasView)
     }
@@ -46,7 +47,8 @@ class ViewController: UIViewController {
                            width: self.view.frame.width - canvasView.frame.width,
                            height: self.view.frame.height)
         let stylerView = StylerView(frame: frame,
-                                    backgroundColor: .white)
+                                    backgroundColor: .white,
+                                    viewController: self)
         self.stylerView = stylerView
         self.view.addSubview(stylerView)
     }
@@ -71,7 +73,6 @@ class ViewController: UIViewController {
         plane.addRectangle(rectangle)
         canvasView.insertSubview(rectangleView, belowSubview: canvasView.generatingButton)
     }
-
 }
 
 extension ViewController: UIGestureRecognizerDelegate{
@@ -79,10 +80,10 @@ extension ViewController: UIGestureRecognizerDelegate{
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         
         let tappedPoint = touch.location(in: self.canvasView)
-        guard let rectangle = self.plane[tappedPoint.x,tappedPoint.y] else { return true }
-        guard let stylerView = self.stylerView else { return true }
-        guard let canvasView = self.canvasView else { return true }
-        guard let rectangleView = canvasView[tappedPoint.x,tappedPoint.y] else { return true }
+        guard let rectangle = self.plane[tappedPoint.x,tappedPoint.y] else { return false }
+        guard let stylerView = self.stylerView else { return false }
+        guard let canvasView = self.canvasView else { return false }
+        guard let rectangleView = canvasView[tappedPoint.x,tappedPoint.y] else { return false }
         
         let r = rectangle.backgroundColor.r
         let g = rectangle.backgroundColor.g
@@ -90,8 +91,31 @@ extension ViewController: UIGestureRecognizerDelegate{
         let opacity = rectangle.alpha.opacity
         stylerView.updateRectangleInfo(r: r, g: g, b: b, opacity: opacity)
         canvasView.selectTappedRectangle(subView: rectangleView)
+        self.plane.selectRectangle(id: rectangle.id)
         
         return true
     }
 }
 
+extension ViewController: ViewMutable, ModelMutable{
+    
+    func changeSelectedRectangleViewColor(){
+        
+    }
+    
+    func changeSelectedRectangleViewAlpha(opacity: Int){
+        if let canvasView = self.canvasView{
+            canvasView.changeSelectedRectangleOpacity(opacity: opacity)
+        }
+    }
+    
+    func changeRectangleModelAlpha(opacity: Int) {
+        var opacity = opacity
+        guard let selectedRectangleId = self.plane.selectedRectangleId else { return }
+        guard let rectangle = self.plane[selectedRectangleId] else { return }
+        if(opacity == 10){
+            opacity = opacity - 1
+        }
+        rectangle.alpha = Rectangle.Alpha.allCases[opacity]
+    }
+}

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -80,9 +80,13 @@ extension ViewController: UIGestureRecognizerDelegate{
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         
         let tappedPoint = touch.location(in: self.canvasView)
-        guard let rectangle = self.plane[tappedPoint.x,tappedPoint.y] else { return false }
         guard let stylerView = self.stylerView else { return false }
         guard let canvasView = self.canvasView else { return false }
+        guard let rectangle = self.plane[tappedPoint.x,tappedPoint.y] else {
+            stylerView.clearRectangleInfo()
+            canvasView.cancelSelection()
+            return false
+        }
         guard let rectangleView = canvasView[tappedPoint.x,tappedPoint.y] else { return false }
         
         let r = rectangle.backgroundColor.r
@@ -125,5 +129,9 @@ extension ViewController: ViewMutable, ModelMutable{
         guard let selectedRectangleId = self.plane.selectedRectangleId else { return }
         guard let rectangle = self.plane[selectedRectangleId] else { return }
         rectangle.backgroundColor = Rectangle.Color(r: rgb[0]*255, g: rgb[1]*255, b: rgb[2]*255)
+    }
+    
+    func clearModelSelection() {
+        self.plane.clearModelSelection()
     }
 }

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -6,6 +6,8 @@ class ViewController: UIViewController {
     private var logger: Logger = Logger()
     private var canvasView: CanvasView?
     private var stylerView: StylerView?
+    private var rectangleFactory: RectangleFactory = RectangleFactory()
+    private var plane: Plane = Plane()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -18,20 +20,48 @@ class ViewController: UIViewController {
     }
     
     private func setCanvasView(){
-        let frame = CGRect(x: self.view.frame.minX, y: self.view.frame.minY, width: self.view.frame.width*0.8, height: self.view.frame.height)
-        let canvasView = CanvasView(frame: frame, backGroundColor: .lightGray, buttonActionClosure: {
-            print("closure")
-        })
+        let frame = CGRect(x: self.view.frame.minX,
+                           y: self.view.frame.minY,
+                           width: self.view.frame.width*0.8,
+                           height: self.view.frame.height)
+        let canvasView = CanvasView(frame: frame,
+                                    backGroundColor: .lightGray,
+                                    buttonActionClosure: self.drawRectangle)
         self.canvasView = canvasView
         self.view.addSubview(canvasView)
     }
     
     private func setStylerView(){
         guard let canvasView = self.canvasView else { return }
-        let frame = CGRect(x: canvasView.frame.width, y: self.view.frame.minY, width: self.view.frame.width - canvasView.frame.width, height: self.view.frame.height)
-        let stylerView = StylerView(frame: frame, backgroundColor: .white)
+        let frame = CGRect(x: canvasView.frame.width,
+                           y: self.view.frame.minY,
+                           width: self.view.frame.width - canvasView.frame.width,
+                           height: self.view.frame.height)
+        let stylerView = StylerView(frame: frame,
+                                    backgroundColor: .white)
         self.stylerView = stylerView
         self.view.addSubview(stylerView)
+    }
+    
+    func drawRectangle(){
+        guard let canvasView = self.canvasView else { return }
+        let rectangle = rectangleFactory.createRenctangle(maxX: canvasView.bounds.maxX - 50,
+                                                          maxY: canvasView.bounds.maxY - 250,
+                                                          minWidth: 150,
+                                                          minHeight: 150,
+                                                          maxWidth: 180,
+                                                          maxHeight: 180)
+        let rectangleView = UIView(frame: CGRect(x: rectangle.point.x,
+                                                 y: rectangle.point.y,
+                                                 width: rectangle.size.width,
+                                                 height: rectangle.size.height))
+        rectangleView.backgroundColor = UIColor(red: rectangle.backgroundColor.r,
+                                                green: rectangle.backgroundColor.g,
+                                                blue: rectangle.backgroundColor.b,
+                                                alpha: CGFloat(rectangle.alpha.opacity))
+        
+        plane.addRectangle(rectangle)
+        canvasView.addSubview(rectangleView)
     }
 
 }

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -10,10 +10,8 @@ class ViewController: UIViewController {
         let factory = RectangleFactory()
         for index in 0..<4{
             let rectangle = factory.createRenctangle()
-            logger.debug("Rectangle\(index) : \(rectangle)")
+            logger.debug("Rectangle\(index+1) : \(rectangle)")
         }
     }
-
-
 }
 

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -99,8 +99,10 @@ extension ViewController: UIGestureRecognizerDelegate{
 
 extension ViewController: ViewMutable, ModelMutable{
     
-    func changeSelectedRectangleViewColor(){
-        
+    func changeSelectedRecntagleViewColor(rgb: [Double]){
+        guard let canvasView = self.canvasView else { return }
+        canvasView.changeSelectedRectangleColor(rgb: rgb)
+        changeRectangleModelColor(rgb: rgb)
     }
     
     func changeSelectedRectangleViewAlpha(opacity: Int){
@@ -117,5 +119,11 @@ extension ViewController: ViewMutable, ModelMutable{
             opacity = opacity - 1
         }
         rectangle.alpha = Rectangle.Alpha.allCases[opacity]
+    }
+    
+    func changeRectangleModelColor(rgb: [Double]) {
+        guard let selectedRectangleId = self.plane.selectedRectangleId else { return }
+        guard let rectangle = self.plane[selectedRectangleId] else { return }
+        rectangle.backgroundColor = Rectangle.Color(r: rgb[0]*255, g: rgb[1]*255, b: rgb[2]*255)
     }
 }

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -4,8 +4,8 @@ import OSLog
 class ViewController: UIViewController{
     
     private var logger: Logger = Logger()
-    private weak var canvasView: CanvasView?
-    private weak var stylerView: StylerView?
+    private var canvasView: CanvasView?
+    private var stylerView: StylerView?
     private var plane: Plane = Plane()
     
     override func viewDidLoad() {

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -81,12 +81,15 @@ extension ViewController: UIGestureRecognizerDelegate{
         let tappedPoint = touch.location(in: self.canvasView)
         guard let rectangle = self.plane[tappedPoint.x,tappedPoint.y] else { return true }
         guard let stylerView = self.stylerView else { return true }
+        guard let canvasView = self.canvasView else { return true }
+        guard let rectangleView = canvasView[tappedPoint.x,tappedPoint.y] else { return true }
         
         let r = rectangle.backgroundColor.r
         let g = rectangle.backgroundColor.g
         let b = rectangle.backgroundColor.b
         let opacity = rectangle.alpha.opacity
         stylerView.updateRectangleInfo(r: r, g: g, b: b, opacity: opacity)
+        canvasView.selectTappedRectangle(subView: rectangleView)
         
         return true
     }

--- a/DrawingApp/DrawingApp/Controller/ViewMutable.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewMutable.swift
@@ -2,5 +2,5 @@ import Foundation
 
 
 protocol ViewMutable: AnyObject{
-    func changeSelectedRectangleAlpha(opacity: Int)
+    func changeSelectedRectangleViewAlpha(opacity: Int)
 }

--- a/DrawingApp/DrawingApp/Controller/ViewMutable.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewMutable.swift
@@ -3,4 +3,5 @@ import Foundation
 
 protocol ViewMutable: AnyObject{
     func changeSelectedRectangleViewAlpha(opacity: Int)
+    func changeSelectedRecntagleViewColor(rgb: [Double])
 }

--- a/DrawingApp/DrawingApp/Controller/ViewMutable.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewMutable.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+
+protocol ViewMutable: AnyObject{
+    func changeSelectedRectangleAlpha(opacity: Int)
+}

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -11,6 +11,7 @@ struct Plane:CustomStringConvertible{
     var description: String{
         return self.rectangles.description
     }
+    weak var delegate: PlaneDelegate?
     
     mutating func addRectangle(_ rectangle: Rectangle){
         self.rectangles[rectangle.id] = rectangle

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -21,6 +21,10 @@ struct Plane:CustomStringConvertible{
         self.selectedRectangleId = id
     }
     
+    mutating func clearModelSelection(){
+        self.selectedRectangleId = nil
+    }
+    
     private func isRectangleInsideTheRange(x: Double, y: Double, rectangle: Rectangle)-> Bool{
         
         let minX = rectangle.point.x

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -14,8 +14,10 @@ struct Plane:CustomStringConvertible{
     weak var delegate: PlaneDelegate?
     
     mutating func addRectangle(_ rectangle: Rectangle){
+        guard let delegate = self.delegate else { return }
         self.rectangles[rectangle.id] = rectangle
         self.rectangleIndex.append(rectangle.id)
+        delegate.addingRectangleCompleted(rectangle: rectangle)
     }
     
     mutating func selectRectangle(id: Rectangle.Id){

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -2,8 +2,9 @@ import Foundation
 
 struct Plane:CustomStringConvertible{
     
-    private var rectangles:[String:Rectangle] = [:]
-    private var rectangleIndex:[String] = []
+    private var rectangles:[Rectangle.Id:Rectangle] = [:]
+    private var rectangleIndex:[Rectangle.Id] = []
+    private(set) var selectedRectangleId: Rectangle.Id?
     var count: Int{
         return rectangles.count
     }
@@ -12,8 +13,12 @@ struct Plane:CustomStringConvertible{
     }
     
     mutating func addRectangle(_ rectangle: Rectangle){
-        self.rectangles[rectangle.id.description] = rectangle
-        self.rectangleIndex.append(rectangle.id.description)
+        self.rectangles[rectangle.id] = rectangle
+        self.rectangleIndex.append(rectangle.id)
+    }
+    
+    mutating func selectRectangle(id: Rectangle.Id){
+        self.selectedRectangleId = id
     }
     
     private func isRectangleInsideTheRange(x: Double, y: Double, rectangle: Rectangle)-> Bool{
@@ -29,15 +34,24 @@ struct Plane:CustomStringConvertible{
         return false
     }
     
+    subscript(id: Rectangle.Id)-> Rectangle?{
+        if let rectangle = rectangles[id]{
+            return rectangle
+        }
+        return nil
+    }
+    
     subscript(index: Int = 0)-> Rectangle?{
+        
         if(index < 0 || index >= self.rectangleIndex.count){
             return nil
         }
         return self.rectangles[rectangleIndex[index]]
     }
-
+    
     subscript(x: Double = 0, y: Double = 0)-> Rectangle?{
-        for id in rectangles.keys{
+  
+        for id in rectangleIndex.reversed(){
             guard let rectangle = rectangles[id] else { continue }
             if(isRectangleInsideTheRange(x: x, y: y, rectangle: rectangle)){
                 return rectangle

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -2,19 +2,21 @@ import Foundation
 
 struct Plane{
     
-    private var rectangles:[Rectangle] = []
+    private var rectangles:[String:Rectangle] = [:]
+    private var rectangleIndex:[String] = []
     var count: Int{
         return rectangles.count
     }
     
-    mutating func addRectangle(rectangle: Rectangle){
-        self.rectangles.append(rectangle)
+    mutating func addRectangle(_ rectangle: Rectangle){
+        self.rectangles[rectangle.id.description] = rectangle
+        self.rectangleIndex.append(rectangle.id.description)
     }
     
     subscript(index: Int = 0)-> Rectangle?{
-        if(index <= 0 || index >= self.rectangles.count){
+        if(index <= 0 || index >= self.rectangleIndex.count){
             return nil
         }
-        return self.rectangles[index]
+        return self.rectangles[rectangleIndex[index]]
     }
 }

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -1,1 +1,20 @@
 import Foundation
+
+struct Plane{
+    
+    private var rectangles:[Rectangle] = []
+    var count: Int{
+        return rectangles.count
+    }
+    
+    mutating func addRectangle(rectangle: Rectangle){
+        self.rectangles.append(rectangle)
+    }
+    
+    subscript(index: Int = 0)-> Rectangle?{
+        if(index <= 0 || index >= self.rectangles.count){
+            return nil
+        }
+        return self.rectangles[index]
+    }
+}

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -1,11 +1,14 @@
 import Foundation
 
-struct Plane{
+struct Plane:CustomStringConvertible{
     
     private var rectangles:[String:Rectangle] = [:]
     private var rectangleIndex:[String] = []
     var count: Int{
         return rectangles.count
+    }
+    var description: String{
+        return self.rectangles.description
     }
     
     mutating func addRectangle(_ rectangle: Rectangle){

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -16,10 +16,33 @@ struct Plane:CustomStringConvertible{
         self.rectangleIndex.append(rectangle.id.description)
     }
     
+    private func isRectangleInsideTheRange(x: Double, y: Double, rectangle: Rectangle)-> Bool{
+        
+        let minX = rectangle.point.x
+        let minY = rectangle.point.y
+        let maxX = rectangle.point.x + rectangle.size.width
+        let maxY = rectangle.point.y + rectangle.size.height
+        if((x <= maxX && x >= minX) && (y <= maxY && y >= minY)){
+            return true
+        }
+        
+        return false
+    }
+    
     subscript(index: Int = 0)-> Rectangle?{
-        if(index <= 0 || index >= self.rectangleIndex.count){
+        if(index < 0 || index >= self.rectangleIndex.count){
             return nil
         }
         return self.rectangles[rectangleIndex[index]]
+    }
+
+    subscript(x: Double = 0, y: Double = 0)-> Rectangle?{
+        for id in rectangles.keys{
+            guard let rectangle = rectangles[id] else { continue }
+            if(isRectangleInsideTheRange(x: x, y: y, rectangle: rectangle)){
+                return rectangle
+            }
+        }
+        return nil
     }
 }

--- a/DrawingApp/DrawingApp/Model/PlaneDelegate.swift
+++ b/DrawingApp/DrawingApp/Model/PlaneDelegate.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol PlaneDelegate: AnyObject{
+    func rectangleModelFound()
+}

--- a/DrawingApp/DrawingApp/Model/PlaneDelegate.swift
+++ b/DrawingApp/DrawingApp/Model/PlaneDelegate.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 protocol PlaneDelegate: AnyObject{
-    func rectangleModelFound()
+    func addingRectangleCompleted(rectangle: Rectangle)
 }

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -74,25 +74,21 @@ class Rectangle: CustomStringConvertible{
         }
     }
     
-    struct Alpha: CustomStringConvertible{
+    enum Alpha:Int, CaseIterable, CustomStringConvertible{
         
-        var opacity = 10
+        case one = 1
+        case two = 2
+        case three = 3
+        case four = 4
+        case five = 5
+        case six = 6
+        case seven = 7
+        case eight = 8
+        case nine = 9
+        case ten = 10
+        
         var description: String{
-            return "Alpha:\(String(self.opacity))"
-        }
-        
-        init(opacity: Int){
-            self.opacity = adjustRange(opacity: opacity)
-        }
-        
-        private func adjustRange(opacity: Int)-> Int{
-            if(opacity>10){
-                return 10
-            }else if(opacity<1){
-                return 1
-            }else{
-                return opacity
-            }
+            return "Alpha:\(String(self.rawValue))"
         }
     }
     

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -50,17 +50,27 @@ class Rectangle: CustomStringConvertible{
     }
     
     struct Color:Equatable, CustomStringConvertible{
-        var r: Double
-        var g: Double
-        var b: Double
+        var r: Double = 0
+        var g: Double = 0
+        var b: Double = 0
         var description: String{
             return "r:\(Int(r)),g:\(Int(g)),b:\(Int(b))"
         }
         
         init(r: Double, g: Double, b: Double){
-            self.r = r
-            self.g = g
-            self.b = b
+            self.r = adjustRange(value: r)
+            self.g = adjustRange(value: g)
+            self.b = adjustRange(value: b)
+        }
+        
+        private func adjustRange(value: Double)-> Double{
+            if(value<0){
+                return Double(0)
+            }else if(value>255){
+                return Double(255)
+            }else{
+                return value
+            }
         }
     }
     

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -74,21 +74,25 @@ class Rectangle: CustomStringConvertible{
         }
     }
     
-    enum Alpha:Int, CaseIterable, CustomStringConvertible{
+    struct Alpha: CustomStringConvertible{
         
-        case one = 1
-        case two = 2
-        case three = 3
-        case four = 4
-        case five = 5
-        case six = 6
-        case seven = 7
-        case eight = 8
-        case nine = 9
-        case ten = 10
-        
+        var opacity = 10
         var description: String{
-            return "Alpha:\(String(self.rawValue))"
+            return "Alpha:\(String(self.opacity))"
+        }
+        
+        init(opacity: Int){
+            self.opacity = adjustRange(opacity: opacity)
+        }
+        
+        private func adjustRange(opacity: Int)-> Int{
+            if(opacity>10){
+                return 10
+            }else if(opacity<1){
+                return 1
+            }else{
+                return opacity
+            }
         }
     }
     

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -2,6 +2,27 @@ import Foundation
 
 class Rectangle: CustomStringConvertible{
     
+    struct Id:CustomStringConvertible{
+        private var idValue: String
+        var description: String{
+            return self.idValue
+        }
+        
+        init(){
+            var asciiValues: [Int] = []
+            asciiValues.append(contentsOf: Array(97...122))
+            asciiValues.append(contentsOf: Array(48...57))
+            
+            var characters: [Character] = []
+            while(characters.count != 9){
+                guard let value = UnicodeScalar(asciiValues[Int.random(in: 0..<asciiValues.count)]) else { continue }
+                let character = Character(value)
+                characters.append(character)
+            }
+            self.idValue = "\(String(characters[0...2]))-\(String(characters[3...5]))-\(String(characters[6...8]))"
+        }
+    }
+    
     struct Size: Equatable, CustomStringConvertible{
         var width: Double
         var height: Double
@@ -61,7 +82,7 @@ class Rectangle: CustomStringConvertible{
         }
     }
     
-    private var id: String
+    private var id: Id
     private var size: Size
     private var point: Point
     private var backgroundColor: Color
@@ -70,7 +91,7 @@ class Rectangle: CustomStringConvertible{
         return "(\(id)), \(size), \(point), \(backgroundColor), \(alpha)"
     }
     
-    init(id: String, size: Size, point: Point, backgroundColor: Color, alpha: Alpha){
+    init(id: Id, size: Size, point: Point, backgroundColor: Color, alpha: Alpha){
         self.id = id
         self.size = size
         self.point = point

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -91,8 +91,8 @@ class Rectangle: CustomStringConvertible{
             return "Alpha:\(String(self.rawValue))"
         }
         
-        var opacity: Int{
-            return self.rawValue
+        var opacity: Float{
+            return Float(self.rawValue) / 10
         }
     }
     

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -58,9 +58,9 @@ class Rectangle: CustomStringConvertible{
         }
         
         init(r: Double, g: Double, b: Double){
-            self.r = adjustRange(value: r)
-            self.g = adjustRange(value: g)
-            self.b = adjustRange(value: b)
+            self.r = adjustRange(value: r)/255
+            self.g = adjustRange(value: g)/255
+            self.b = adjustRange(value: b)/255
         }
         
         private func adjustRange(value: Double)-> Double{
@@ -96,11 +96,11 @@ class Rectangle: CustomStringConvertible{
         }
     }
     
-    private var id: Id
-    private var size: Size
-    private var point: Point
-    private var backgroundColor: Color
-    private var alpha: Alpha
+    var id: Id
+    var size: Size
+    var point: Point
+    var backgroundColor: Color
+    var alpha: Alpha
     var description: String{
         return "(\(id)), \(size), \(point), \(backgroundColor), \(alpha)"
     }

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -54,7 +54,7 @@ class Rectangle: CustomStringConvertible{
         var g: Double = 0
         var b: Double = 0
         var description: String{
-            return "r:\(Int(r)),g:\(Int(g)),b:\(Int(b))"
+            return "r:\(Int(r*255)),g:\(Int(g*255)),b:\(Int(b*255))"
         }
         
         init(r: Double, g: Double, b: Double){

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class Rectangle: CustomStringConvertible{
     
-    struct Id:CustomStringConvertible{
+    struct Id:CustomStringConvertible, Hashable{
         private var idValue: String
         var description: String{
             return self.idValue

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -90,6 +90,10 @@ class Rectangle: CustomStringConvertible{
         var description: String{
             return "Alpha:\(String(self.rawValue))"
         }
+        
+        var opacity: Int{
+            return self.rawValue
+        }
     }
     
     private var id: Id

--- a/DrawingApp/DrawingApp/Model/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Model/RectangleFactory.swift
@@ -2,13 +2,6 @@ import Foundation
 
 class RectangleFactory{
     
-    private var asciiValues: [Int] = []
-    
-    init(){
-        asciiValues.append(contentsOf: Array(97...122))
-        asciiValues.append(contentsOf: Array(48...57))
-    }
-    
     func createRenctangle()-> Rectangle{
         let id = createRandomStringId()
         let point = createRandomPoint()
@@ -19,15 +12,8 @@ class RectangleFactory{
         return Rectangle(id: id, size: size, point: point, backgroundColor: color, alpha: alpha)
     }
     
-    private func createRandomStringId()-> String{
-        
-        var characters: [Character] = []
-        while(characters.count != 9){
-            guard let value = UnicodeScalar(asciiValues[Int.random(in: 0..<asciiValues.count)]) else { continue }
-            let character = Character(value)
-            characters.append(character)
-        }
-        return "\(String(characters[0...2]))-\(String(characters[3...5]))-\(String(characters[6...8]))"
+    private func createRandomStringId()-> Rectangle.Id{
+        return Rectangle.Id()
     }
     
     private func createRandomPoint()-> Rectangle.Point{

--- a/DrawingApp/DrawingApp/Model/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Model/RectangleFactory.swift
@@ -2,10 +2,10 @@ import Foundation
 
 class RectangleFactory{
     
-    func createRenctangle()-> Rectangle{
+    func createRenctangle(maxX: Double, maxY: Double, minWidth: Double, minHeight: Double, maxWidth: Double, maxHeight: Double)-> Rectangle{
         let id = createRandomStringId()
-        let point = createRandomPoint()
-        let size = createRandomRectangleSize()
+        let point = createRandomPoint(maxX: maxX, maxY: maxY)
+        let size = createRandomRectangleSize(minWidth: minWidth, minHeight: minHeight, maxWidth: maxWidth, maxHeight: maxHeight)
         let color = createRandomColor()
         let alpha = createRandomAlpha()
         
@@ -16,12 +16,12 @@ class RectangleFactory{
         return Rectangle.Id()
     }
     
-    private func createRandomPoint()-> Rectangle.Point{
-        return Rectangle.Point(x: Double.random(in: 1...100), y: Double.random(in: 1...100))
+    private func createRandomPoint(maxX: Double, maxY: Double)-> Rectangle.Point{
+        return Rectangle.Point(x: Double.random(in: 1...maxX), y: Double.random(in: 1...maxY))
     }
     
-    private func createRandomRectangleSize()-> Rectangle.Size{
-        return Rectangle.Size(width: Double.random(in: 1...100), height: Double.random(in: 1...100))
+    private func createRandomRectangleSize(minWidth: Double, minHeight: Double, maxWidth: Double, maxHeight: Double)-> Rectangle.Size{
+        return Rectangle.Size(width: Double.random(in: minWidth...maxWidth), height: Double.random(in: minHeight...maxHeight))
     }
     
     private func createRandomColor()-> Rectangle.Color{

--- a/DrawingApp/DrawingApp/Model/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Model/RectangleFactory.swift
@@ -29,6 +29,6 @@ class RectangleFactory{
     }
     
     private func createRandomAlpha()-> Rectangle.Alpha{
-        return Rectangle.Alpha.allCases[Int.random(in: 0...9)]
+        return Rectangle.Alpha(opacity: Int.random(in: 0...11))
     }
 }

--- a/DrawingApp/DrawingApp/Model/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Model/RectangleFactory.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class RectangleFactory{
     
-    func createRenctangle(maxX: Double, maxY: Double, minWidth: Double, minHeight: Double, maxWidth: Double, maxHeight: Double)-> Rectangle{
+    static func createRenctangle(maxX: Double, maxY: Double, minWidth: Double, minHeight: Double, maxWidth: Double, maxHeight: Double)-> Rectangle{
         let id = createRandomStringId()
         let point = createRandomPoint(maxX: maxX, maxY: maxY)
         let size = createRandomRectangleSize(minWidth: minWidth, minHeight: minHeight, maxWidth: maxWidth, maxHeight: maxHeight)
@@ -12,23 +12,23 @@ class RectangleFactory{
         return Rectangle(id: id, size: size, point: point, backgroundColor: color, alpha: alpha)
     }
     
-    private func createRandomStringId()-> Rectangle.Id{
+    private static func createRandomStringId()-> Rectangle.Id{
         return Rectangle.Id()
     }
     
-    private func createRandomPoint(maxX: Double, maxY: Double)-> Rectangle.Point{
+    private static func createRandomPoint(maxX: Double, maxY: Double)-> Rectangle.Point{
         return Rectangle.Point(x: Double.random(in: 1...maxX), y: Double.random(in: 1...maxY))
     }
     
-    private func createRandomRectangleSize(minWidth: Double, minHeight: Double, maxWidth: Double, maxHeight: Double)-> Rectangle.Size{
+    private static func createRandomRectangleSize(minWidth: Double, minHeight: Double, maxWidth: Double, maxHeight: Double)-> Rectangle.Size{
         return Rectangle.Size(width: Double.random(in: minWidth...maxWidth), height: Double.random(in: minHeight...maxHeight))
     }
     
-    private func createRandomColor()-> Rectangle.Color{
+    private static func createRandomColor()-> Rectangle.Color{
         return Rectangle.Color(r: Double.random(in: 0...255), g: Double.random(in: 0...255), b: Double.random(in: 0...255))
     }
     
-    private func createRandomAlpha()-> Rectangle.Alpha{
+    private static func createRandomAlpha()-> Rectangle.Alpha{
         return Rectangle.Alpha.allCases[Int.random(in: 0...9)]
     }
 }

--- a/DrawingApp/DrawingApp/Model/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Model/RectangleFactory.swift
@@ -29,6 +29,6 @@ class RectangleFactory{
     }
     
     private func createRandomAlpha()-> Rectangle.Alpha{
-        return Rectangle.Alpha(opacity: Int.random(in: 0...11))
+        return Rectangle.Alpha.allCases[Int.random(in: 0...9)]
     }
 }

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -1,0 +1,6 @@
+import Foundation
+import UIKit
+
+class CanvasView: UIView{
+    
+}

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -3,16 +3,15 @@ import UIKit
 
 class CanvasView: UIView{
     
-    private var viewController: ModelMutable?
+    weak var viewController: ModelMutable?
     private (set) var generatingButton: UIButton = UIButton()
     private (set) var selectedRectangleView: UIView?
     
-    init(frame: CGRect, backGroundColor: UIColor, buttonActionClosure: @escaping ()->Void, viewController: ModelMutable) {
+    init(frame: CGRect, backGroundColor: UIColor, buttonActionClosure: @escaping ()->Void) {
         super.init(frame: frame)
         self.backgroundColor = backGroundColor
         setGeneratingButton()
         setGeneratingButtonAction(buttonActionClosure: buttonActionClosure)
-        self.viewController = viewController
     }
         
     required init?(coder: NSCoder) {

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -3,7 +3,7 @@ import UIKit
 
 class CanvasView: UIView{
     
-    private var generatingButton: UIButton = UIButton()
+    private (set) var generatingButton: UIButton = UIButton()
     
     init(frame: CGRect, backGroundColor: UIColor, buttonActionClosure: @escaping ()->Void) {
         super.init(frame: frame)

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -4,6 +4,7 @@ import UIKit
 class CanvasView: UIView{
     
     private (set) var generatingButton: UIButton = UIButton()
+    private var selectedRectangleView: UIView?
     
     init(frame: CGRect, backGroundColor: UIColor, buttonActionClosure: @escaping ()->Void) {
         super.init(frame: frame)
@@ -14,6 +15,14 @@ class CanvasView: UIView{
         
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+    
+    func selectTappedRectangle(subView: UIView){
+        if let selectedRectangleView = self.selectedRectangleView {
+            selectedRectangleView.layer.borderWidth = 0
+        }
+        subView.layer.borderWidth = 2
+        self.selectedRectangleView = subView
     }
     
     private func setGeneratingButton(){
@@ -37,6 +46,23 @@ class CanvasView: UIView{
         let buttonAction:UIAction = UIAction(title: ""){ _ in
             buttonActionClosure() }
         self.generatingButton.addAction(buttonAction, for: .touchDown)
+    }
+    
+    subscript(x: Double, y: Double)-> UIView?{
+        func isTappedPointInsideTheRange(view: UIView)-> Bool{
+            if((x <= view.frame.maxX && x >= view.frame.minX) && (y <= view.frame.maxY && y >= view.frame.minY)){
+                return true
+            }
+            return false
+        }
+        
+        for view in self.subviews{
+            if(isTappedPointInsideTheRange(view: view)){
+                return view
+            }
+        }
+        
+        return nil
     }
 
 }

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -3,4 +3,38 @@ import UIKit
 
 class CanvasView: UIView{
     
+    private var generatingButton: UIButton = UIButton()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setGeneratingButton()
+    }
+        
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func setGeneratingButton(){
+        let buttonWidth = self.frame.width*0.15
+        let buttonHeight = self.frame.height*0.15
+        self.generatingButton.frame = CGRect(x: 0, y: self.frame.height-buttonHeight, width: buttonWidth, height: buttonHeight*0.8)
+        self.generatingButton.center.x = self.center.x
+        
+        self.generatingButton.backgroundColor = .white
+        self.generatingButton.layer.cornerRadius = 10
+        self.generatingButton.layer.borderWidth = 2
+        
+        self.generatingButton.setTitle("사각형🖌", for: .normal)
+        self.generatingButton.setTitleColor(.black, for: .normal)
+        self.generatingButton.titleLabel?.font = UIFont.systemFont(ofSize: 30)
+        
+        self.addSubview(generatingButton)
+    }
+    
+    func setGeneratingButtonAction(buttonActionClosure: @escaping ()->Void){
+        let buttonAction:UIAction = UIAction(title: ""){ _ in
+            buttonActionClosure() }
+        self.generatingButton.addAction(buttonAction, for: .touchDown)
+    }
+
 }

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -3,14 +3,16 @@ import UIKit
 
 class CanvasView: UIView{
     
+    private var viewController: ModelMutable?
     private (set) var generatingButton: UIButton = UIButton()
-    private var selectedRectangleView: UIView?
+    private (set) var selectedRectangleView: UIView?
     
-    init(frame: CGRect, backGroundColor: UIColor, buttonActionClosure: @escaping ()->Void) {
+    init(frame: CGRect, backGroundColor: UIColor, buttonActionClosure: @escaping ()->Void, viewController: ModelMutable) {
         super.init(frame: frame)
         self.backgroundColor = backGroundColor
         setGeneratingButton()
         setGeneratingButtonAction(buttonActionClosure: buttonActionClosure)
+        self.viewController = viewController
     }
         
     required init?(coder: NSCoder) {
@@ -23,6 +25,13 @@ class CanvasView: UIView{
         }
         subView.layer.borderWidth = 2
         self.selectedRectangleView = subView
+    }
+    
+    func changeSelectedRectangleOpacity(opacity: Int){
+        guard let viewController = self.viewController else { return }
+        guard let selectedRectangleView = selectedRectangleView else { return }
+        selectedRectangleView.alpha = CGFloat(opacity) / 10
+        viewController.changeRectangleModelAlpha(opacity: opacity)
     }
     
     private func setGeneratingButton(){

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -19,6 +19,16 @@ class CanvasView: UIView{
         super.init(coder: coder)
     }
     
+    func cancelSelection(){
+        if let selectedRectangleView = self.selectedRectangleView,
+           let viewController = self.viewController {
+            selectedRectangleView.layer.borderWidth = 0
+            self.selectedRectangleView = nil
+            
+            viewController.clearModelSelection()
+        }
+    }
+    
     func selectTappedRectangle(subView: UIView){
         if let selectedRectangleView = self.selectedRectangleView {
             selectedRectangleView.layer.borderWidth = 0

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -24,11 +24,11 @@ class CanvasView: UIView{
         
         self.generatingButton.backgroundColor = .white
         self.generatingButton.layer.cornerRadius = 10
-        self.generatingButton.layer.borderWidth = 2
+        self.generatingButton.layer.borderWidth = 1
         
         self.generatingButton.setTitle("사각형🖌", for: .normal)
         self.generatingButton.setTitleColor(.black, for: .normal)
-        self.generatingButton.titleLabel?.font = UIFont.systemFont(ofSize: 30)
+        self.generatingButton.titleLabel?.font = UIFont.systemFont(ofSize: 20)
         
         self.addSubview(generatingButton)
     }

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -34,6 +34,11 @@ class CanvasView: UIView{
         viewController.changeRectangleModelAlpha(opacity: opacity)
     }
     
+    func changeSelectedRectangleColor(rgb: [Double]){
+        guard let selectedRectangleView = selectedRectangleView else { return }
+        selectedRectangleView.backgroundColor = UIColor(red: rgb[0], green: rgb[1], blue: rgb[2], alpha: 1)
+    }
+    
     private func setGeneratingButton(){
         let buttonWidth = self.frame.width*0.15
         let buttonHeight = self.frame.height*0.15

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -5,9 +5,11 @@ class CanvasView: UIView{
     
     private var generatingButton: UIButton = UIButton()
     
-    override init(frame: CGRect) {
+    init(frame: CGRect, backGroundColor: UIColor, buttonActionClosure: @escaping ()->Void) {
         super.init(frame: frame)
+        self.backgroundColor = backGroundColor
         setGeneratingButton()
+        setGeneratingButtonAction(buttonActionClosure: buttonActionClosure)
     }
         
     required init?(coder: NSCoder) {
@@ -31,7 +33,7 @@ class CanvasView: UIView{
         self.addSubview(generatingButton)
     }
     
-    func setGeneratingButtonAction(buttonActionClosure: @escaping ()->Void){
+    private func setGeneratingButtonAction(buttonActionClosure: @escaping ()->Void){
         let buttonAction:UIAction = UIAction(title: ""){ _ in
             buttonActionClosure() }
         self.generatingButton.addAction(buttonAction, for: .touchDown)

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -3,7 +3,7 @@ import UIKit
 
 class CanvasView: UIView{
     
-    weak var viewController: ModelMutable?
+    weak var delegate: CanvasViewDelegate?
     private (set) var generatingButton: UIButton = UIButton()
     private (set) var selectedRectangleView: UIView?
     
@@ -20,7 +20,7 @@ class CanvasView: UIView{
     
     func cancelSelection(){
         if let selectedRectangleView = self.selectedRectangleView,
-           let viewController = self.viewController {
+           let viewController = self.delegate {
             selectedRectangleView.layer.borderWidth = 0
             self.selectedRectangleView = nil
             
@@ -37,7 +37,7 @@ class CanvasView: UIView{
     }
     
     func changeSelectedRectangleOpacity(opacity: Int){
-        guard let viewController = self.viewController else { return }
+        guard let viewController = self.delegate else { return }
         guard let selectedRectangleView = selectedRectangleView else { return }
         selectedRectangleView.alpha = CGFloat(opacity) / 10
         viewController.changeRectangleModelAlpha(opacity: opacity)

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -7,11 +7,11 @@ class CanvasView: UIView{
     private (set) var generatingButton: UIButton = UIButton()
     private (set) var selectedRectangleView: UIView?
     
-    init(frame: CGRect, backGroundColor: UIColor, buttonActionClosure: @escaping ()->Void) {
+    init(frame: CGRect, backGroundColor: UIColor) {
         super.init(frame: frame)
         self.backgroundColor = backGroundColor
         setGeneratingButton()
-        setGeneratingButtonAction(buttonActionClosure: buttonActionClosure)
+        setGeneratingButtonAction()
     }
         
     required init?(coder: NSCoder) {
@@ -23,7 +23,6 @@ class CanvasView: UIView{
            let viewController = self.delegate {
             selectedRectangleView.layer.borderWidth = 0
             self.selectedRectangleView = nil
-            
             viewController.clearModelSelection()
         }
     }
@@ -65,10 +64,17 @@ class CanvasView: UIView{
         self.addSubview(generatingButton)
     }
     
-    private func setGeneratingButtonAction(buttonActionClosure: @escaping ()->Void){
+    private func setGeneratingButtonAction(){
         let buttonAction:UIAction = UIAction(title: ""){ _ in
-            buttonActionClosure() }
+            self.sendCreatingRectangleRequest()
+        }
         self.generatingButton.addAction(buttonAction, for: .touchDown)
+    }
+    
+    private func sendCreatingRectangleRequest(){
+        if let delegate = self.delegate{
+            delegate.creatingRectangleRequested()
+        }
     }
     
     subscript(x: Double, y: Double)-> UIView?{

--- a/DrawingApp/DrawingApp/View/CanvasViewDeleagte.swift
+++ b/DrawingApp/DrawingApp/View/CanvasViewDeleagte.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol ModelMutable: AnyObject{
+protocol CanvasViewDelegate: AnyObject{
     
     func changeRectangleModelAlpha(opacity: Int)
     func changeRectangleModelColor(rgb: [Double])

--- a/DrawingApp/DrawingApp/View/CanvasViewDeleagte.swift
+++ b/DrawingApp/DrawingApp/View/CanvasViewDeleagte.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol CanvasViewDelegate: AnyObject{
-    
+    func creatingRectangleRequested()
     func changeRectangleModelAlpha(opacity: Int)
     func changeRectangleModelColor(rgb: [Double])
     func clearModelSelection()

--- a/DrawingApp/DrawingApp/View/GeneratorView.swift
+++ b/DrawingApp/DrawingApp/View/GeneratorView.swift
@@ -1,0 +1,7 @@
+import Foundation
+import UIKit
+
+
+class GeneratorView: UIView{
+    
+}

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -3,4 +3,53 @@ import UIKit
 
 class StylerView: UIView{
     
+    private var rectangleColorTextLabel: UILabel = UILabel()
+    private var rectangleColorValueField: UILabel = UILabel()
+    private var rectangleAlphaTextLabel: UILabel = UILabel()
+    private var rectangleAlphaSlider: UISlider = UISlider()
+    
+    init(frame: CGRect, backgroundColor: UIColor){
+        super.init(frame: frame)
+        self.backgroundColor = backgroundColor
+        setRectangleColorInformationView()
+        setRectangleAlphaInformationView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func setRectangleColorInformationView(){
+        self.rectangleColorTextLabel.text = "배경색"
+        self.rectangleColorTextLabel.frame = CGRect(x: self.frame.width*0.1,
+                                                    y: self.frame.height*0.07,
+                                                    width: 100,
+                                                    height: self.frame.height*0.05)
+        self.addSubview(self.rectangleColorTextLabel)
+        
+        self.rectangleColorValueField.frame = CGRect(x: self.frame.width*0.1,
+                                                     y: self.rectangleColorTextLabel.frame.maxY+10,
+                                                     width: self.frame.width*0.75,
+                                                     height: self.frame.height*0.05)
+        self.rectangleColorValueField.layer.cornerRadius = 10
+        self.rectangleColorValueField.layer.borderWidth = 1
+        self.addSubview(self.rectangleColorValueField)
+    }
+    
+    private func setRectangleAlphaInformationView(){
+        self.rectangleAlphaTextLabel.text = "투명도"
+        self.rectangleAlphaTextLabel.frame = CGRect(x: self.frame.width*0.1,
+                                                    y: self.rectangleColorValueField.frame.maxY+25,
+                                                    width: 100,
+                                                    height: self.frame.height*0.05)
+        self.addSubview(self.rectangleAlphaTextLabel)
+        
+        self.rectangleAlphaSlider.frame = CGRect(x: self.frame.width*0.1,
+                                                 y: self.rectangleAlphaTextLabel.frame.maxY+10,
+                                                 width: self.frame.width*0.75,
+                                                 height: 10)
+        self.rectangleAlphaSlider.value = 10
+        self.addSubview(self.rectangleAlphaSlider)
+    }
+    
 }

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -5,7 +5,7 @@ class StylerView: UIView{
     
     private var viewController: ViewMutable?
     private var rectangleColorTextLabel: UILabel = UILabel()
-    private var rectangleColorValueField: UILabel = UILabel()
+    private var rectangleColorValueField: UIButton = UIButton()
     private var rectangleAlphaTextLabel: UILabel = UILabel()
     private var rectangleAlphaSlider: UISlider = UISlider()
     
@@ -25,8 +25,8 @@ class StylerView: UIView{
     
     func updateRectangleInfo(r: Double, g: Double, b: Double, opacity: Float){
         let hexString = "#\(String(Int(r*255), radix: 16))\(String(Int(g*255), radix: 16))\(String(Int(b*255), radix: 16))"
-        self.rectangleColorValueField.text = hexString
-        self.rectangleColorValueField.textAlignment = .center
+        self.rectangleColorValueField.setTitle(hexString, for: .normal)
+        self.rectangleColorValueField.titleLabel?.textAlignment = .center
         self.rectangleColorValueField.backgroundColor = UIColor(red: r, green: g, blue: b, alpha: 1)
         self.rectangleAlphaSlider.value = opacity
     }
@@ -49,6 +49,18 @@ class StylerView: UIView{
     }
     
     private func setColorChangeAction(){
+        self.rectangleColorValueField.addAction(UIAction(title: ""){_ in
+            let newColor = UIColor(red: CGFloat.random(in: 0...1),
+                                   green: CGFloat.random(in: 0...1),
+                                   blue: CGFloat.random(in: 0...1),
+                                   alpha: 1)
+            guard let rgb = newColor.cgColor.components else { return }
+            guard let viewController = self.viewController else { return }
+            let newHexString = "#\(String(Int(rgb[0]*255), radix: 16))\(String(Int(rgb[1]*255), radix: 16))\(String(Int(rgb[2]*255), radix: 16))"
+            self.rectangleColorValueField.backgroundColor = newColor
+            self.rectangleColorValueField.setTitle(newHexString, for: .normal)
+            viewController.changeSelectedRecntagleViewColor(rgb: rgb.map{Double($0)})
+        }, for: .touchDown)
     }
     
     private func setRectangleAlphaInformationView(){

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -3,15 +3,14 @@ import UIKit
 
 class StylerView: UIView{
     
-    private var viewController: ViewMutable?
+    weak var viewController: ViewMutable?
     private var rectangleColorTextLabel: UILabel = UILabel()
     private var rectangleColorValueField: UIButton = UIButton()
     private var rectangleAlphaTextLabel: UILabel = UILabel()
     private var rectangleAlphaSlider: UISlider = UISlider()
     
-    init(frame: CGRect, backgroundColor: UIColor, viewController: ViewMutable){
+    init(frame: CGRect, backgroundColor: UIColor){
         super.init(frame: frame)
-        self.viewController = viewController
         self.backgroundColor = backgroundColor
         setRectangleColorInformationView()
         setColorChangeAction()

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -19,6 +19,14 @@ class StylerView: UIView{
         super.init(coder: coder)
     }
     
+    func updateRectangleInfo(r: Double, g: Double, b: Double, opacity: Float){
+        
+        let hexString = "#\(String(Int(r*255), radix: 16))\(String(Int(g*255), radix: 16))\(String(Int(b*255), radix: 16))"
+        self.rectangleColorValueField.text = hexString
+        self.rectangleColorValueField.textAlignment = .center
+        self.rectangleAlphaSlider.value = opacity
+    }
+    
     private func setRectangleColorInformationView(){
         self.rectangleColorTextLabel.text = "배경색"
         self.rectangleColorTextLabel.frame = CGRect(x: self.frame.width*0.1,

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -3,7 +3,7 @@ import UIKit
 
 class StylerView: UIView{
     
-    weak var viewController: ViewMutable?
+    weak var delegate: StylerViewDelegate?
     private var rectangleColorTextLabel: UILabel = UILabel()
     private var rectangleColorValueField: UIButton = UIButton()
     private var rectangleAlphaTextLabel: UILabel = UILabel()
@@ -60,7 +60,7 @@ class StylerView: UIView{
                                    blue: CGFloat.random(in: 0...1),
                                    alpha: 1)
             guard let rgb = newColor.cgColor.components else { return }
-            guard let viewController = self.viewController else { return }
+            guard let viewController = self.delegate else { return }
             let newHexString = "#\(String(Int(rgb[0]*255), radix: 16))\(String(Int(rgb[1]*255), radix: 16))\(String(Int(rgb[2]*255), radix: 16))"
             self.rectangleColorValueField.backgroundColor = newColor
             self.rectangleColorValueField.setTitle(newHexString, for: .normal)
@@ -86,7 +86,7 @@ class StylerView: UIView{
     
     private func setAlphaChangeAction(){
         self.rectangleAlphaSlider.addAction(UIAction(title: ""){ _ in
-            if let viewController = self.viewController{
+            if let viewController = self.delegate{
                 viewController.changeSelectedRectangleViewAlpha(opacity: Int(self.rectangleAlphaSlider.value * 10))
             }
         }, for: .valueChanged)

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -3,16 +3,20 @@ import UIKit
 
 class StylerView: UIView{
     
+    private var viewController: ViewMutable?
     private var rectangleColorTextLabel: UILabel = UILabel()
     private var rectangleColorValueField: UILabel = UILabel()
     private var rectangleAlphaTextLabel: UILabel = UILabel()
     private var rectangleAlphaSlider: UISlider = UISlider()
     
-    init(frame: CGRect, backgroundColor: UIColor){
+    init(frame: CGRect, backgroundColor: UIColor, viewController: ViewMutable){
         super.init(frame: frame)
+        self.viewController = viewController
         self.backgroundColor = backgroundColor
         setRectangleColorInformationView()
+        setColorChangeAction()
         setRectangleAlphaInformationView()
+        setAlphaChangeAction()
     }
     
     required init?(coder: NSCoder) {
@@ -20,10 +24,10 @@ class StylerView: UIView{
     }
     
     func updateRectangleInfo(r: Double, g: Double, b: Double, opacity: Float){
-        
         let hexString = "#\(String(Int(r*255), radix: 16))\(String(Int(g*255), radix: 16))\(String(Int(b*255), radix: 16))"
         self.rectangleColorValueField.text = hexString
         self.rectangleColorValueField.textAlignment = .center
+        self.rectangleColorValueField.backgroundColor = UIColor(red: r, green: g, blue: b, alpha: 1)
         self.rectangleAlphaSlider.value = opacity
     }
     
@@ -44,6 +48,9 @@ class StylerView: UIView{
         self.addSubview(self.rectangleColorValueField)
     }
     
+    private func setColorChangeAction(){
+    }
+    
     private func setRectangleAlphaInformationView(){
         self.rectangleAlphaTextLabel.text = "투명도"
         self.rectangleAlphaTextLabel.frame = CGRect(x: self.frame.width*0.1,
@@ -58,6 +65,14 @@ class StylerView: UIView{
                                                  height: 10)
         self.rectangleAlphaSlider.value = 10
         self.addSubview(self.rectangleAlphaSlider)
+    }
+    
+    private func setAlphaChangeAction(){
+        self.rectangleAlphaSlider.addAction(UIAction(title: ""){ _ in
+            if let viewController = self.viewController{
+                viewController.changeSelectedRectangleViewAlpha(opacity: Int(self.rectangleAlphaSlider.value * 10))
+            }
+        }, for: .valueChanged)
     }
     
 }

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -1,0 +1,6 @@
+import Foundation
+import UIKit
+
+class StylerView: UIView{
+    
+}

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -23,6 +23,12 @@ class StylerView: UIView{
         super.init(coder: coder)
     }
     
+    func clearRectangleInfo(){
+        self.rectangleAlphaSlider.value = 0
+        self.rectangleColorValueField.backgroundColor = .white
+        self.rectangleColorValueField.setTitle("", for: .normal)
+    }
+    
     func updateRectangleInfo(r: Double, g: Double, b: Double, opacity: Float){
         let hexString = "#\(String(Int(r*255), radix: 16))\(String(Int(g*255), radix: 16))\(String(Int(b*255), radix: 16))"
         self.rectangleColorValueField.setTitle(hexString, for: .normal)

--- a/DrawingApp/DrawingApp/View/StylerViewDelegate.swift
+++ b/DrawingApp/DrawingApp/View/StylerViewDelegate.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 
-protocol ViewMutable: AnyObject{
+protocol StylerViewDelegate: AnyObject{
     func changeSelectedRectangleViewAlpha(opacity: Int)
     func changeSelectedRecntagleViewColor(rgb: [Double])
 }

--- a/DrawingApp/DrawingAppTests/PlaneTest.swift
+++ b/DrawingApp/DrawingAppTests/PlaneTest.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import DrawingApp
+
+class PlaneTest: XCTestCase {
+
+    
+    func testAddingRectangles(){
+        var plane = Plane()
+        let rectangle = Rectangle(id: Rectangle.Id(), size: Rectangle.Size(width: 200, height: 200), point: Rectangle.Point(x: 100, y: 100), backgroundColor: Rectangle.Color(r: 10, g: 10, b: 10), alpha: Rectangle.Alpha.eight)
+        plane.addRectangle(rectangle)
+        
+        XCTAssertEqual(plane.count, 1)
+    }
+    
+    func testRandomRectangleCorrectlyInTheGivenRange(){
+        var plane = Plane()
+        let rectangle = Rectangle(id: Rectangle.Id(), size: Rectangle.Size(width: 200, height: 200), point: Rectangle.Point(x: 100, y: 100), backgroundColor: Rectangle.Color(r: 10, g: 10, b: 10), alpha: Rectangle.Alpha.eight)
+        plane.addRectangle(rectangle)
+        
+        XCTAssertNotNil(plane[150,150])
+        XCTAssertNil(plane[400,400])
+    }
+}


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/68586291/156718581-c14d8940-7075-4cb2-90e6-bce36b785c0d.gif" style="width:30%; height:20%;"/>

## 작업 내용
- [x] Plane 구조체 생성 및 유닛테스트
    - [x] 생성한 사각형 모델 Plane에 추가
    - [x] 사각형 전체 개수 알려주는 computed property 선언  
    - [x] 인덱스 및 터치 좌표 넘겨서 사각형 모델을 리턴하는 Subscript 정의 
- [x] 사각형 터치할 때 해당 위치에 사각형 있으면 테두리 효과로 선택 표시
- [x] 사각형 선택했을 때 선택된 사각형의 배경색 및 투명도 화면 우측에 표시
- [x] 선택한 사각형의 투명도를 우측 슬라이더로 조정
- [x] 선택한 사각형의 배경색을 버튼 터치를 통해 랜덤으로 변경   
    
## 학습 키워드
- Protocol
- Subscript
- UIView, UIColor, UIGestureRecognizer
- Escaping Closure
    
## 고민과 해결
- 기존 1단계 피드백을 반영해서 Rectangle.Color 내부의 rgb의 범위를 0~255로 제한하는 로직을 추가했습니다.
    - 모든 Double 타입을 생성자 파라미터로 받을 수 있도록 하되, 0 미만의 값은 모두 0으로, 255를 초과하는 값은 모두 255로 강제로 수정하도록 하였습니다.
    
 - CanvasView, StylerView의 수정 혹은 Plane 내부의 Rectangle 객체의 값 수정 등은 모두 ViewController을 매개하여 일어나도록 했습니다.
     - CanvasView, StylerView 각각의 View가 ViewController을 내부에서 참조하되, UIViewController타입이 아닌 각각 ViewMutable, ModelMutable 프로토콜 타입으로 참조하도록 했습니다.
     - 각각의 View가 ViewController의 모든 부분을 알고 있기 보단, 필요한 부분만 알고 있는 것이 낫기에 별도의 프로토콜 타입으로 ViewController을 참조하는 것이 나을 것이라 생각했습니다.
     - StylerView가 슬라이더 혹은 배경색 버튼을 통해 디자인을 변경하면 ViewMutable 프로토콜의 메소드를 호출하여 ViewController가 CanvasView의 사각형 뷰 디자인을 바꾸는 메소드를 호출하도록 했습니다.
     - 반대로, CanvasView에서 배경색 혹은 투명도 등의 디자인이 변경되면 ModelMutable 프로토콜의 메소드를 호출하여 ViewController가 Plane의 Rectangle 모델 값을 변경하는 메소드를 호출하도록 했습니다.
     
- Plane, CanvasView가 모두 현재 선택된 사각형 관련 정보를 가진 프로퍼티를 가지도록 했습니다.
    - CanvasView의 경우 현재 선택된 SubView를 별도의 selectedRectangleView 프로퍼티가 참조하도록 했습니다.
    - Plane의 경우에는 현재 선택된 사각형에 대응되는 Rectangle 모델의 id값을 selectedRectangleId 프로퍼티가 참조하도록 했습니다. 

