### PR TITLE
[Jed] Step 3-2 : 속성 변경 동작 구현 리팩토링

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		B5E73BCC27D1340F0016E628 /* StylerViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BCB27D1340F0016E628 /* StylerViewDelegate.swift */; };
 		B5E73BCE27D138300016E628 /* CanvasViewDeleagte.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BCD27D138300016E628 /* CanvasViewDeleagte.swift */; };
 		B5E73BE127D1E5690016E628 /* PlaneTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BD227D1E5040016E628 /* PlaneTest.swift */; };
+		B5F1536627D4E16A009CA3DE /* RectangleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F1536527D4E16A009CA3DE /* RectangleView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +56,7 @@
 		B5E73BCD27D138300016E628 /* CanvasViewDeleagte.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasViewDeleagte.swift; sourceTree = "<group>"; };
 		B5E73BD227D1E5040016E628 /* PlaneTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneTest.swift; sourceTree = "<group>"; };
 		B5E73BD827D1E5610016E628 /* DrawingAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DrawingAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B5F1536527D4E16A009CA3DE /* RectangleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,6 +147,7 @@
 				B5E73BC727D083750016E628 /* StylerView.swift */,
 				B5E73BCB27D1340F0016E628 /* StylerViewDelegate.swift */,
 				B5E73BCD27D138300016E628 /* CanvasViewDeleagte.swift */,
+				B5F1536527D4E16A009CA3DE /* RectangleView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -260,6 +263,7 @@
 			files = (
 				B5E73BB727CDE3910016E628 /* RectangleFactory.swift in Sources */,
 				B5E73BC427D082630016E628 /* CanvasView.swift in Sources */,
+				B5F1536627D4E16A009CA3DE /* RectangleView.swift in Sources */,
 				B5E73BCC27D1340F0016E628 /* StylerViewDelegate.swift in Sources */,
 				B5E73BC827D083750016E628 /* StylerView.swift in Sources */,
 				B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */,

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -57,17 +57,13 @@ class ViewController: UIViewController{
         self.view.addSubview(stylerView)
     }
     
-    private func updateViewWithSelectedRectangleModel(rectangle: Rectangle, rectangleView: UIView?){
-        if let stylerView = self.stylerView, let canvasView = self.canvasView{
-            let r = rectangle.backgroundColor.r
-            let g = rectangle.backgroundColor.g
-            let b = rectangle.backgroundColor.b
-            let opacity = rectangle.alpha.opacity
-            stylerView.updateRectangleInfo(r: r, g: g, b: b, opacity: opacity)
-            if let rectangleView = rectangleView{
-                canvasView.updateSelectedRectangleView(subView: rectangleView)
-            }
-        }
+    private func updateViewWithSelectedRectangleModel(rectangle: Rectangle){
+        guard let stylerView = self.stylerView else { return }
+        let r = rectangle.backgroundColor.r
+        let g = rectangle.backgroundColor.g
+        let b = rectangle.backgroundColor.b
+        let opacity = rectangle.alpha.opacity
+        stylerView.updateRectangleInfo(r: r, g: g, b: b, opacity: opacity)
     }
 
 }
@@ -100,8 +96,7 @@ extension ViewController: PlaneDelegate{
     }
     
     func rectangleFoundFromPlane(rectangle: Rectangle){
-        guard let currentlyTouchedView = self.currentlyTouchedView else { return }
-        self.updateViewWithSelectedRectangleModel(rectangle: rectangle, rectangleView: currentlyTouchedView)
+        self.updateViewWithSelectedRectangleModel(rectangle: rectangle)
     }
     
     func rectangleNotFoundFromPlane(){
@@ -141,6 +136,12 @@ extension ViewController: CanvasViewDelegate{
 }
 
 extension ViewController: StylerViewDelegate{
+    
+    func updatingRectangleInfoCompleted() {
+        guard let canvasView = self.canvasView else { return }
+        guard let rectangleView = self.currentlyTouchedView else { return }
+        canvasView.updateSelectedRectangleView(subView: rectangleView)
+    }
     
     func updatingSelectedRecntagleViewColorRequested(){
         guard let stylerView = self.stylerView else { return }

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -13,19 +13,23 @@ struct Plane:CustomStringConvertible{
     }
     weak var delegate: PlaneDelegate?
     
+    mutating func findMatchingRectangleModel(x: Double, y: Double){
+        if let delegate = self.delegate{
+            guard let rectangle = self[x,y] else {
+                delegate.rectangleNotFoundFromPlane()
+                return
+            }
+            self.selectedRectangleId = rectangle.id
+            delegate.rectangleFoundFromPlane(rectangle: rectangle)
+        }
+    }
+    
     mutating func addRectangle(_ rectangle: Rectangle){
-        guard let delegate = self.delegate else { return }
         self.rectangles[rectangle.id] = rectangle
         self.rectangleIndex.append(rectangle.id)
-        delegate.addingRectangleCompleted(rectangle: rectangle)
-    }
-    
-    mutating func selectRectangle(id: Rectangle.Id){
-        self.selectedRectangleId = id
-    }
-    
-    mutating func clearModelSelection(){
-        self.selectedRectangleId = nil
+        if let delegate = self.delegate{
+            delegate.addingRectangleCompleted(rectangle: rectangle)
+        }
     }
     
     private func isRectangleInsideTheRange(x: Double, y: Double, rectangle: Rectangle)-> Bool{

--- a/DrawingApp/DrawingApp/Model/PlaneDelegate.swift
+++ b/DrawingApp/DrawingApp/Model/PlaneDelegate.swift
@@ -2,4 +2,6 @@ import Foundation
 
 protocol PlaneDelegate: AnyObject{
     func addingRectangleCompleted(rectangle: Rectangle)
+    func rectangleFoundFromPlane(rectangle: Rectangle)
+    func rectangleNotFoundFromPlane()
 }

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -18,33 +18,34 @@ class CanvasView: UIView{
         super.init(coder: coder)
     }
     
-    func cancelSelection(){
-        if let selectedRectangleView = self.selectedRectangleView,
-           let viewController = self.delegate {
+    func clearRectangleViewSelection(){
+        if let selectedRectangleView = self.selectedRectangleView{
             selectedRectangleView.layer.borderWidth = 0
             self.selectedRectangleView = nil
-            viewController.clearModelSelection()
         }
     }
     
-    func selectTappedRectangle(subView: UIView){
-        if let selectedRectangleView = self.selectedRectangleView {
+    func updateSelectedRectangleView(subView: UIView){
+        if let selectedRectangleView = self.selectedRectangleView{
             selectedRectangleView.layer.borderWidth = 0
         }
         subView.layer.borderWidth = 2
         self.selectedRectangleView = subView
     }
     
-    func changeSelectedRectangleOpacity(opacity: Int){
-        guard let viewController = self.delegate else { return }
+    func updateSelectedRectangleOpacity(opacity: Int){
+        guard let delegate = self.delegate else { return }
         guard let selectedRectangleView = selectedRectangleView else { return }
         selectedRectangleView.alpha = CGFloat(opacity) / 10
-        viewController.changeRectangleModelAlpha(opacity: opacity)
+        delegate.updatingSelectedRectangleViewAlphaCompleted(opacity: opacity)
     }
     
-    func changeSelectedRectangleColor(rgb: [Double]){
+    func changeSelectedRectangleViewColor(rgb: [Double]){
         guard let selectedRectangleView = selectedRectangleView else { return }
         selectedRectangleView.backgroundColor = UIColor(red: rgb[0], green: rgb[1], blue: rgb[2], alpha: 1)
+        if let delegate = self.delegate{
+            delegate.updatingSelectedRectangleViewColorCompleted(rgb: rgb)
+        }
     }
     
     private func setGeneratingButton(){
@@ -75,23 +76,6 @@ class CanvasView: UIView{
         if let delegate = self.delegate{
             delegate.creatingRectangleRequested()
         }
-    }
-    
-    subscript(x: Double, y: Double)-> UIView?{
-        func isTappedPointInsideTheRange(view: UIView)-> Bool{
-            if((x <= view.frame.maxX && x >= view.frame.minX) && (y <= view.frame.maxY && y >= view.frame.minY)){
-                return true
-            }
-            return false
-        }
-        
-        for view in self.subviews{
-            if(isTappedPointInsideTheRange(view: view)){
-                return view
-            }
-        }
-        
-        return nil
     }
 
 }

--- a/DrawingApp/DrawingApp/View/CanvasViewDeleagte.swift
+++ b/DrawingApp/DrawingApp/View/CanvasViewDeleagte.swift
@@ -2,7 +2,6 @@ import Foundation
 
 protocol CanvasViewDelegate: AnyObject{
     func creatingRectangleRequested()
-    func changeRectangleModelAlpha(opacity: Int)
-    func changeRectangleModelColor(rgb: [Double])
-    func clearModelSelection()
+    func updatingSelectedRectangleViewAlphaCompleted(opacity: Int)
+    func updatingSelectedRectangleViewColorCompleted(rgb: [Double])
 }

--- a/DrawingApp/DrawingApp/View/RectangleView.swift
+++ b/DrawingApp/DrawingApp/View/RectangleView.swift
@@ -1,0 +1,14 @@
+import Foundation
+import UIKit
+
+class RectangleView: UIView{
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+        
+}

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -37,6 +37,9 @@ class StylerView: UIView{
         self.rectangleColorValueField.titleLabel?.textAlignment = .center
         self.rectangleColorValueField.backgroundColor = UIColor(red: r, green: g, blue: b, alpha: 1)
         self.rectangleAlphaSlider.value = opacity
+        if let delegate = self.delegate{
+            delegate.updatingRectangleInfoCompleted()
+        }
     }
     
     private func setRectangleColorInformationView(){

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -59,7 +59,7 @@ class StylerView: UIView{
     private func setColorChangeAction(){
         self.rectangleColorValueField.addAction(UIAction(title: ""){_ in
             if let delegate = self.delegate{
-                delegate.updatingSelectedRecntagleViewColorRequessted()
+                delegate.updatingSelectedRecntagleViewColorRequested()
             }
         }, for: .touchDown)
     }

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -22,10 +22,13 @@ class StylerView: UIView{
         super.init(coder: coder)
     }
     
-    func clearRectangleInfo(){
+    func clearSelectedRectangleInfo(){
         self.rectangleAlphaSlider.value = 0
         self.rectangleColorValueField.backgroundColor = .white
         self.rectangleColorValueField.setTitle("", for: .normal)
+        if let delegate = self.delegate{
+            delegate.clearingSelectedRectangleInfoCompleted()
+        }
     }
     
     func updateRectangleInfo(r: Double, g: Double, b: Double, opacity: Float){
@@ -55,16 +58,9 @@ class StylerView: UIView{
     
     private func setColorChangeAction(){
         self.rectangleColorValueField.addAction(UIAction(title: ""){_ in
-            let newColor = UIColor(red: CGFloat.random(in: 0...1),
-                                   green: CGFloat.random(in: 0...1),
-                                   blue: CGFloat.random(in: 0...1),
-                                   alpha: 1)
-            guard let rgb = newColor.cgColor.components else { return }
-            guard let viewController = self.delegate else { return }
-            let newHexString = "#\(String(Int(rgb[0]*255), radix: 16))\(String(Int(rgb[1]*255), radix: 16))\(String(Int(rgb[2]*255), radix: 16))"
-            self.rectangleColorValueField.backgroundColor = newColor
-            self.rectangleColorValueField.setTitle(newHexString, for: .normal)
-            viewController.changeSelectedRecntagleViewColor(rgb: rgb.map{Double($0)})
+            if let delegate = self.delegate{
+                delegate.updatingSelectedRecntagleViewColorRequessted()
+            }
         }, for: .touchDown)
     }
     
@@ -86,10 +82,23 @@ class StylerView: UIView{
     
     private func setAlphaChangeAction(){
         self.rectangleAlphaSlider.addAction(UIAction(title: ""){ _ in
-            if let viewController = self.delegate{
-                viewController.changeSelectedRectangleViewAlpha(opacity: Int(self.rectangleAlphaSlider.value * 10))
+            if let delegate = self.delegate{
+                delegate.updatingSelectedRectangleViewAlphaRequested(opacity: Int(self.rectangleAlphaSlider.value * 10))
             }
         }, for: .valueChanged)
+    }
+    
+    func updateSelectedRectangleViewColorInfo(rgb: [Double]){
+        let newHexString = "#\(String(Int(rgb[0]*255), radix: 16))\(String(Int(rgb[1]*255), radix: 16))\(String(Int(rgb[2]*255), radix: 16))"
+        self.rectangleColorValueField.backgroundColor = UIColor(red: rgb[0],
+                                                                green: rgb[1],
+                                                                blue: rgb[2],
+                                                                alpha: 1)
+        self.rectangleColorValueField.setTitle(newHexString, for: .normal)
+        if let delegate = self.delegate{
+            delegate.updatingSelectedRectangleViewColorInfoCompleted(rgb: rgb)
+        }
+
     }
     
 }

--- a/DrawingApp/DrawingApp/View/StylerViewDelegate.swift
+++ b/DrawingApp/DrawingApp/View/StylerViewDelegate.swift
@@ -2,6 +2,7 @@ import Foundation
 
 
 protocol StylerViewDelegate: AnyObject{
+    func updatingRectangleInfoCompleted()
     func updatingSelectedRectangleViewAlphaRequested(opacity: Int)
     func updatingSelectedRecntagleViewColorRequested()
     func updatingSelectedRectangleViewColorInfoCompleted(rgb: [Double])

--- a/DrawingApp/DrawingApp/View/StylerViewDelegate.swift
+++ b/DrawingApp/DrawingApp/View/StylerViewDelegate.swift
@@ -2,6 +2,8 @@ import Foundation
 
 
 protocol StylerViewDelegate: AnyObject{
-    func changeSelectedRectangleViewAlpha(opacity: Int)
-    func changeSelectedRecntagleViewColor(rgb: [Double])
+    func updatingSelectedRectangleViewAlphaRequested(opacity: Int)
+    func updatingSelectedRecntagleViewColorRequested()
+    func updatingSelectedRectangleViewColorInfoCompleted(rgb: [Double])
+    func clearingSelectedRectangleInfoCompleted()
 }


### PR DESCRIPTION
> 3단계 진행하면서 리팩토링 같이하려 했으나, 리팩토링한 코드의 양이 많은 것 같아서 우선 피드백을 부탁드리려고 먼저 PR 보냈습니다!
## 작업 내용
![image](https://user-images.githubusercontent.com/68586291/156930112-79ff7901-51c3-4fe9-8008-52d62c326990.png)

- [x] Model, ViewController, View의 각각의 메소드가 입출력 중 하나의 기능만 수행하도록 메소드 세분화
    
## 고민과 해결
- 앞서 주신 피드백 중  __`입출력이 모델,뷰,컨트롤러로 단방향으로 가는 흐름이 되도록 수정`__ 해야 한다고 해주신 부분을 우선 반영하여 수정했습니다.
- __`입력 -> 입력된 데이터 처리 -> 처리된 데이터 기반 출력`__ 의 과정을 어느 하나의 메소드에서 2개이상 처리하도록 하지 않고 최대한 하나의 메소드가 하나씩만 처리해서 처리 결과를 단방향으로 보내도록 수정했습니다.
- 기존에 작성한 몇몇 메소드명이 입력용인지 출력용인지 알아보기 힘들어서 __`updatingColorCompleted`__ , __`updatingColorRequested`__ 와 같은 식으로 특정 입출력이 요구되거나 혹은 요구사항에 대한 처리가 완료되었음을 직접적으로 알려주도록 수정하였습니다.
- __`gestureRecognizer()`__ 메소드에서 현재 터치된 UIView가 RectangleView인 지 클래스 타입을 통해 알 수 있도록 하기 위해 별도로 UIView를 상속받는 RectangleView 클래스를 정의하였습니다. 
(UIView 서브 클래스의 생성자 관련하여 일관되게 작성하도록 이전에 피드백 주셨는데, 이 부분은 아직 수정중입니다!)