### PR TITLE
[Jed] Step 3-3 : 옵저버 패턴 적용, 리팩토링

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B5A777B427D3909A0055E311 /* PlaneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A777B327D3909A0055E311 /* PlaneDelegate.swift */; };
+		B5B137BC27D9C8AE0033F9A5 /* RectangleViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B137BB27D9C8AE0033F9A5 /* RectangleViewFactory.swift */; };
 		B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */; };
 		B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BA127CDC29E0016E628 /* SceneDelegate.swift */; };
 		B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BA327CDC29E0016E628 /* ViewController.swift */; };
@@ -38,6 +39,7 @@
 
 /* Begin PBXFileReference section */
 		B5A777B327D3909A0055E311 /* PlaneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneDelegate.swift; sourceTree = "<group>"; };
+		B5B137BB27D9C8AE0033F9A5 /* RectangleViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleViewFactory.swift; sourceTree = "<group>"; };
 		B5E73B9C27CDC29E0016E628 /* DrawingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrawingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B5E73BA127CDC29E0016E628 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 				B5E73BCB27D1340F0016E628 /* StylerViewDelegate.swift */,
 				B5E73BCD27D138300016E628 /* CanvasViewDeleagte.swift */,
 				B5F1536527D4E16A009CA3DE /* RectangleView.swift */,
+				B5B137BB27D9C8AE0033F9A5 /* RectangleViewFactory.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -263,6 +266,7 @@
 			files = (
 				B5E73BB727CDE3910016E628 /* RectangleFactory.swift in Sources */,
 				B5E73BC427D082630016E628 /* CanvasView.swift in Sources */,
+				B5B137BC27D9C8AE0033F9A5 /* RectangleViewFactory.swift in Sources */,
 				B5F1536627D4E16A009CA3DE /* RectangleView.swift in Sources */,
 				B5E73BCC27D1340F0016E628 /* StylerViewDelegate.swift in Sources */,
 				B5E73BC827D083750016E628 /* StylerView.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B5A777B427D3909A0055E311 /* PlaneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A777B327D3909A0055E311 /* PlaneDelegate.swift */; };
 		B5B137BC27D9C8AE0033F9A5 /* RectangleViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B137BB27D9C8AE0033F9A5 /* RectangleViewFactory.swift */; };
 		B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */; };
 		B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BA127CDC29E0016E628 /* SceneDelegate.swift */; };
@@ -38,7 +37,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		B5A777B327D3909A0055E311 /* PlaneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneDelegate.swift; sourceTree = "<group>"; };
 		B5B137BB27D9C8AE0033F9A5 /* RectangleViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleViewFactory.swift; sourceTree = "<group>"; };
 		B5E73B9C27CDC29E0016E628 /* DrawingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrawingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -121,7 +119,6 @@
 				B5E73BB427CDC2F90016E628 /* Rectangle.swift */,
 				B5E73BB627CDE3910016E628 /* RectangleFactory.swift */,
 				B5E73BBB27CF457B0016E628 /* Plane.swift */,
-				B5A777B327D3909A0055E311 /* PlaneDelegate.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -271,7 +268,6 @@
 				B5E73BCC27D1340F0016E628 /* StylerViewDelegate.swift in Sources */,
 				B5E73BC827D083750016E628 /* StylerView.swift in Sources */,
 				B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */,
-				B5A777B427D3909A0055E311 /* PlaneDelegate.swift in Sources */,
 				B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */,
 				B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */,
 				B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */,

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -98,14 +98,14 @@ class ViewController: UIViewController{
     }
     
     @objc func updateSelectedRecntalgeViewColor(_ notification: Notification){
-        guard let rgb = notification.object as? [Double] else { return }
+        guard let newColor = notification.object as? Rectangle.Color else { return }
         guard let stylerView = self.stylerView else { return }
         guard let canvasView = self.canvasView else { return }
         
-        let newColor = UIColor(red: rgb[0], green: rgb[1], blue: rgb[2], alpha: 1)
-        let newHexString = "#\(String(Int(rgb[0]*255), radix: 16))\(String(Int(rgb[1]*255), radix: 16))\(String(Int(rgb[2]*255), radix: 16))"
-        stylerView.updateSelectedRectangleViewColorInfo(newColor: newColor, newHexString: newHexString)
-        canvasView.updateSelectedRectangleViewColor(newColor: newColor)
+        let newUIColor = UIColor(red: newColor.r, green: newColor.g, blue: newColor.b, alpha: 1)
+        let newHexString = "#\(String(Int(newColor.r*255), radix: 16))\(String(Int(newColor.g*255), radix: 16))\(String(Int(newColor.b*255), radix: 16))"
+        stylerView.updateSelectedRectangleViewColorInfo(newColor: newUIColor, newHexString: newHexString)
+        canvasView.updateSelectedRectangleViewColor(newColor: newUIColor)
     }
     
     @objc func updateSelectedRectangleViewAlpha(_ notification: Notification){
@@ -147,17 +147,8 @@ extension ViewController: CanvasViewDelegate{
 extension ViewController: StylerViewDelegate{
     
     func updatingSelectedRectangleColorRequested(){
-        let newColor = generateNewColor()
-        guard let components = newColor.cgColor.components else { return }
-        let rgb = components.map{Double($0)}
-        self.plane.updateRectangleColor(rgb: rgb)
-    }
-    
-    private func generateNewColor()-> UIColor{
-        return UIColor(red: CGFloat.random(in: 0...1),
-                       green: CGFloat.random(in: 0...1),
-                       blue: CGFloat.random(in: 0...1),
-                       alpha: 1)
+        let newColor = RectangleFactory.createRandomColor()
+        self.plane.updateRectangleColor(newColor: newColor)
     }
     
     func updatingSelectedRectangleAlphaRequested(opacity: Int){

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -84,14 +84,7 @@ extension ViewController: PlaneDelegate{
     
     func addingRectangleCompleted(rectangle: Rectangle) {
         guard let canvasView = self.canvasView else { return }
-        let rectangleView = RectangleView(frame: CGRect(x: rectangle.point.x,
-                                                 y: rectangle.point.y,
-                                                 width: rectangle.size.width,
-                                                 height: rectangle.size.height))
-        rectangleView.backgroundColor = UIColor(red: rectangle.backgroundColor.r,
-                                                green: rectangle.backgroundColor.g,
-                                                blue: rectangle.backgroundColor.b,
-                                                alpha: CGFloat(rectangle.alpha.opacity))
+        let rectangleView = RectangleViewFactory.createRectangleView(rectangle: rectangle)
         canvasView.insertSubview(rectangleView, belowSubview: canvasView.generatingButton)
     }
     

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -128,9 +128,11 @@ extension ViewController: CanvasViewDelegate{
         rectangle.alpha = Rectangle.Alpha.allCases[opacity]
     }
     
-    func updatingSelectedRectangleViewColorCompleted(rgb: [Double]) {
+    func updatingSelectedRectangleViewColorCompleted(newColor: UIColor) {
         guard let selectedRectangleId = plane.selectedRectangleId else { return }
         guard let rectangle = plane[selectedRectangleId] else { return }
+        guard let components = newColor.cgColor.components else { return }
+        let rgb = components.map{Double($0)}
         rectangle.backgroundColor = Rectangle.Color(r: rgb[0]*255, g: rgb[1]*255, b: rgb[2]*255)
     }
 }
@@ -145,25 +147,22 @@ extension ViewController: StylerViewDelegate{
     
     func updatingSelectedRecntagleViewColorRequested(){
         guard let stylerView = self.stylerView else { return }
-        guard let rgb = generateNewColor() else { return }
-        stylerView.updateSelectedRectangleViewColorInfo(rgb: rgb)
+        let newColor = generateNewColor()
+        guard let rgb = newColor.cgColor.components else { return }
+        let newHexString = "#\(String(Int(rgb[0]*255), radix: 16))\(String(Int(rgb[1]*255), radix: 16))\(String(Int(rgb[2]*255), radix: 16))"
+        stylerView.updateSelectedRectangleViewColorInfo(newColor: newColor, newHexString: newHexString)
     }
     
-    private func generateNewColor()-> [Double]?{
-        let newColor = UIColor(red: CGFloat.random(in: 0...1),
-                               green: CGFloat.random(in: 0...1),
-                               blue: CGFloat.random(in: 0...1),
-                               alpha: 1)
-        var rgb:[Double]?
-        if let components = newColor.cgColor.components{
-            rgb = components.map{ Double($0) }
-        }
-        return rgb
+    private func generateNewColor()-> UIColor{
+        return UIColor(red: CGFloat.random(in: 0...1),
+                       green: CGFloat.random(in: 0...1),
+                       blue: CGFloat.random(in: 0...1),
+                       alpha: 1)
     }
     
-    func updatingSelectedRectangleViewColorInfoCompleted(rgb: [Double]) {
+    func updatingSelectedRectangleViewColorInfoCompleted(newColor: UIColor) {
         guard let canvasView = self.canvasView else { return }
-        canvasView.changeSelectedRectangleViewColor(rgb: rgb)
+        canvasView.changeSelectedRectangleViewColor(newColor: newColor)
     }
     
     func updatingSelectedRectangleViewAlphaRequested(opacity: Int){

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -120,8 +120,17 @@ class ViewController: UIViewController{
 extension ViewController: UIGestureRecognizerDelegate{
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        /*
+           1. 우선 터치된 곳에 해당하는 touch.view의 타입이 RectangleView인 경우에는,
+              현재 터치된 사각형뷰를 임시로 저장한 currentlyTouchedView의 인스턴스로 할당
+           2. 이후 Plane에서 터치된 x,y를 가지고 유효한 모델이 내부에 존재하는 지 검증되면 이후 뷰에서 뷰컨트롤러로 값 변경 요청이 들어오면 currentlyTouchedView를 사용하여 사각형 뷰의 배경색 혹은 투명도를 바꿀 수 있도록 함
+           3. 단, 이후 터치된 곳에 해당하는 touch.view가 RectangleView가 아닌 경우에는, 사각형이 없는 부분을 터치한 것이므로 currentlyTouchedView를 다시 nil로 초기화
+         */
+        
         if let touchedView = touch.view as? RectangleView{
             self.currentlyTouchedView = touchedView
+        }else{
+            self.currentlyTouchedView = nil
         }
         let touchedPoint = touch.location(in: self.canvasView)
         self.plane.findMatchingRectangleModel(x: touchedPoint.x, y: touchedPoint.y)

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct Plane:CustomStringConvertible{
     
+    private var notificationCenter = NotificationCenter.default
     private var rectangles:[Rectangle.Id:Rectangle] = [:]
     private(set) var selectedRectangleId: Rectangle.Id?
     var count: Int{
@@ -10,24 +11,19 @@ struct Plane:CustomStringConvertible{
     var description: String{
         return self.rectangles.description
     }
-    weak var delegate: PlaneDelegate?
     
     mutating func findMatchingRectangleModel(x: Double, y: Double){
-        if let delegate = self.delegate{
-            guard let rectangle = self[x,y] else {
-                delegate.rectangleNotFoundFromPlane()
-                return
-            }
-            self.selectedRectangleId = rectangle.id
-            delegate.rectangleFoundFromPlane(rectangle: rectangle)
+        guard let rectangle = self[x,y] else {
+            self.notificationCenter.post(name: .rectangleNotFoundFromPlane, object: nil)
+            return
         }
+        self.selectedRectangleId = rectangle.id
+        self.notificationCenter.post(name: .rectangleFoundFromPlane, object: rectangle, userInfo: nil)
     }
     
     mutating func addRectangle(_ rectangle: Rectangle){
         self.rectangles[rectangle.id] = rectangle
-        if let delegate = self.delegate{
-            delegate.addingRectangleCompleted(rectangle: rectangle)
-        }
+        self.notificationCenter.post(name: .rectangleAdded, object: rectangle, userInfo: nil)
     }
     
     private func isRectangleInsideTheRange(x: Double, y: Double, rectangle: Rectangle)-> Bool{

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -3,7 +3,6 @@ import Foundation
 struct Plane:CustomStringConvertible{
     
     private var rectangles:[Rectangle.Id:Rectangle] = [:]
-    private var rectangleIndex:[Rectangle.Id] = []
     private(set) var selectedRectangleId: Rectangle.Id?
     var count: Int{
         return rectangles.count
@@ -26,7 +25,6 @@ struct Plane:CustomStringConvertible{
     
     mutating func addRectangle(_ rectangle: Rectangle){
         self.rectangles[rectangle.id] = rectangle
-        self.rectangleIndex.append(rectangle.id)
         if let delegate = self.delegate{
             delegate.addingRectangleCompleted(rectangle: rectangle)
         }
@@ -52,17 +50,9 @@ struct Plane:CustomStringConvertible{
         return nil
     }
     
-    subscript(index: Int = 0)-> Rectangle?{
-        
-        if(index < 0 || index >= self.rectangleIndex.count){
-            return nil
-        }
-        return self.rectangles[rectangleIndex[index]]
-    }
-    
     subscript(x: Double = 0, y: Double = 0)-> Rectangle?{
   
-        for id in rectangleIndex.reversed(){
+        for id in self.rectangles.keys{
             guard let rectangle = rectangles[id] else { continue }
             if(isRectangleInsideTheRange(x: x, y: y, rectangle: rectangle)){
                 return rectangle

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -14,6 +14,7 @@ struct Plane:CustomStringConvertible{
     
     mutating func findMatchingRectangleModel(x: Double, y: Double){
         guard let rectangle = self[x,y] else {
+            self.selectedRectangleId = nil
             self.notificationCenter.post(name: .rectangleNotFoundFromPlane, object: nil)
             return
         }
@@ -24,6 +25,24 @@ struct Plane:CustomStringConvertible{
     mutating func addRectangle(_ rectangle: Rectangle){
         self.rectangles[rectangle.id] = rectangle
         self.notificationCenter.post(name: .rectangleAdded, object: rectangle, userInfo: nil)
+    }
+    
+    mutating func updateRectangleColor(rgb: [Double]){
+        guard let selectedRectangleId = self.selectedRectangleId else { return }
+        guard let rectangle = self.rectangles[selectedRectangleId] else { return }
+        rectangle.backgroundColor = Rectangle.Color(r: rgb[0]*255, g: rgb[1]*255, b: rgb[2]*255)
+        self.notificationCenter.post(name: .rectangleColorUpdated, object: rgb)
+    }
+    
+    mutating func updateRectangleAlpha(opacity: Int){
+        var opacity = opacity
+        guard let selectedRectangleId = self.selectedRectangleId else { return }
+        guard let rectangle = self.rectangles[selectedRectangleId] else { return }
+        if(opacity == 10){
+            opacity = opacity - 1
+        }
+        rectangle.alpha = Rectangle.Alpha.allCases[opacity]
+        self.notificationCenter.post(name: .rectangleAlphaUpdated, object: opacity)
     }
     
     private func isRectangleInsideTheRange(x: Double, y: Double, rectangle: Rectangle)-> Bool{

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -27,11 +27,11 @@ struct Plane:CustomStringConvertible{
         self.notificationCenter.post(name: .rectangleAdded, object: rectangle, userInfo: nil)
     }
     
-    mutating func updateRectangleColor(rgb: [Double]){
+    mutating func updateRectangleColor(newColor: Rectangle.Color){
         guard let selectedRectangleId = self.selectedRectangleId else { return }
         guard let rectangle = self.rectangles[selectedRectangleId] else { return }
-        rectangle.backgroundColor = Rectangle.Color(r: rgb[0]*255, g: rgb[1]*255, b: rgb[2]*255)
-        self.notificationCenter.post(name: .rectangleColorUpdated, object: rgb)
+        rectangle.backgroundColor = newColor
+        self.notificationCenter.post(name: .rectangleColorUpdated, object: newColor)
     }
     
     mutating func updateRectangleAlpha(opacity: Int){

--- a/DrawingApp/DrawingApp/Model/PlaneDelegate.swift
+++ b/DrawingApp/DrawingApp/Model/PlaneDelegate.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-protocol PlaneDelegate: AnyObject{
-    func addingRectangleCompleted(rectangle: Rectangle)
-    func rectangleFoundFromPlane(rectangle: Rectangle)
-    func rectangleNotFoundFromPlane()
-}

--- a/DrawingApp/DrawingApp/Model/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Model/RectangleFactory.swift
@@ -24,7 +24,7 @@ class RectangleFactory{
         return Rectangle.Size(width: Double.random(in: minWidth...maxWidth), height: Double.random(in: minHeight...maxHeight))
     }
     
-    private static func createRandomColor()-> Rectangle.Color{
+    static func createRandomColor()-> Rectangle.Color{
         return Rectangle.Color(r: Double.random(in: 0...255), g: Double.random(in: 0...255), b: Double.random(in: 0...255))
     }
     

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -34,18 +34,13 @@ class CanvasView: UIView{
     }
     
     func updateSelectedRectangleOpacity(opacity: Int){
-        guard let delegate = self.delegate else { return }
         guard let selectedRectangleView = selectedRectangleView else { return }
         selectedRectangleView.alpha = CGFloat(opacity) / 10
-        delegate.updatingSelectedRectangleViewAlphaCompleted(opacity: opacity)
     }
     
-    func changeSelectedRectangleViewColor(newColor: UIColor){
+    func updateSelectedRectangleViewColor(newColor: UIColor){
         guard let selectedRectangleView = selectedRectangleView else { return }
         selectedRectangleView.backgroundColor = newColor
-        if let delegate = self.delegate{
-            delegate.updatingSelectedRectangleViewColorCompleted(newColor: newColor)
-        }
     }
     
     private func setGeneratingButton(){

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -40,11 +40,11 @@ class CanvasView: UIView{
         delegate.updatingSelectedRectangleViewAlphaCompleted(opacity: opacity)
     }
     
-    func changeSelectedRectangleViewColor(rgb: [Double]){
+    func changeSelectedRectangleViewColor(newColor: UIColor){
         guard let selectedRectangleView = selectedRectangleView else { return }
-        selectedRectangleView.backgroundColor = UIColor(red: rgb[0], green: rgb[1], blue: rgb[2], alpha: 1)
+        selectedRectangleView.backgroundColor = newColor
         if let delegate = self.delegate{
-            delegate.updatingSelectedRectangleViewColorCompleted(rgb: rgb)
+            delegate.updatingSelectedRectangleViewColorCompleted(newColor: newColor)
         }
     }
     

--- a/DrawingApp/DrawingApp/View/CanvasViewDeleagte.swift
+++ b/DrawingApp/DrawingApp/View/CanvasViewDeleagte.swift
@@ -1,7 +1,8 @@
 import Foundation
+import UIKit
 
 protocol CanvasViewDelegate: AnyObject{
     func creatingRectangleRequested()
     func updatingSelectedRectangleViewAlphaCompleted(opacity: Int)
-    func updatingSelectedRectangleViewColorCompleted(rgb: [Double])
+    func updatingSelectedRectangleViewColorCompleted(newColor: UIColor)
 }

--- a/DrawingApp/DrawingApp/View/CanvasViewDeleagte.swift
+++ b/DrawingApp/DrawingApp/View/CanvasViewDeleagte.swift
@@ -3,6 +3,4 @@ import UIKit
 
 protocol CanvasViewDelegate: AnyObject{
     func creatingRectangleRequested()
-    func updatingSelectedRectangleViewAlphaCompleted(opacity: Int)
-    func updatingSelectedRectangleViewColorCompleted(newColor: UIColor)
 }

--- a/DrawingApp/DrawingApp/View/RectangleViewFactory.swift
+++ b/DrawingApp/DrawingApp/View/RectangleViewFactory.swift
@@ -1,0 +1,2 @@
+import Foundation
+

--- a/DrawingApp/DrawingApp/View/RectangleViewFactory.swift
+++ b/DrawingApp/DrawingApp/View/RectangleViewFactory.swift
@@ -1,2 +1,17 @@
 import Foundation
+import UIKit
 
+class RectangleViewFactory{
+    
+    static func createRectangleView(rectangle: Rectangle)-> RectangleView{
+        let rectangleView = RectangleView(frame: CGRect(x: rectangle.point.x,
+                                                 y: rectangle.point.y,
+                                                 width: rectangle.size.width,
+                                                 height: rectangle.size.height))
+        rectangleView.backgroundColor = UIColor(red: rectangle.backgroundColor.r,
+                                                green: rectangle.backgroundColor.g,
+                                                blue: rectangle.backgroundColor.b,
+                                                alpha: CGFloat(rectangle.alpha.opacity))
+        return rectangleView
+    }
+}

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -91,17 +91,12 @@ class StylerView: UIView{
         }, for: .valueChanged)
     }
     
-    func updateSelectedRectangleViewColorInfo(rgb: [Double]){
-        let newHexString = "#\(String(Int(rgb[0]*255), radix: 16))\(String(Int(rgb[1]*255), radix: 16))\(String(Int(rgb[2]*255), radix: 16))"
-        self.rectangleColorValueField.backgroundColor = UIColor(red: rgb[0],
-                                                                green: rgb[1],
-                                                                blue: rgb[2],
-                                                                alpha: 1)
+    func updateSelectedRectangleViewColorInfo(newColor: UIColor, newHexString: String){
+        self.rectangleColorValueField.backgroundColor = newColor
         self.rectangleColorValueField.setTitle(newHexString, for: .normal)
         if let delegate = self.delegate{
-            delegate.updatingSelectedRectangleViewColorInfoCompleted(rgb: rgb)
+            delegate.updatingSelectedRectangleViewColorInfoCompleted(newColor: newColor)
         }
-
     }
     
 }

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -26,20 +26,13 @@ class StylerView: UIView{
         self.rectangleAlphaSlider.value = 0
         self.rectangleColorValueField.backgroundColor = .white
         self.rectangleColorValueField.setTitle("", for: .normal)
-        if let delegate = self.delegate{
-            delegate.clearingSelectedRectangleInfoCompleted()
-        }
     }
     
-    func updateRectangleInfo(r: Double, g: Double, b: Double, opacity: Float){
-        let hexString = "#\(String(Int(r*255), radix: 16))\(String(Int(g*255), radix: 16))\(String(Int(b*255), radix: 16))"
+    func updateRectangleInfo(r: Double, g: Double, b: Double, opacity: Float, hexString: String){
         self.rectangleColorValueField.setTitle(hexString, for: .normal)
         self.rectangleColorValueField.titleLabel?.textAlignment = .center
         self.rectangleColorValueField.backgroundColor = UIColor(red: r, green: g, blue: b, alpha: 1)
         self.rectangleAlphaSlider.value = opacity
-        if let delegate = self.delegate{
-            delegate.updatingRectangleInfoCompleted()
-        }
     }
     
     private func setRectangleColorInformationView(){
@@ -62,7 +55,7 @@ class StylerView: UIView{
     private func setColorChangeAction(){
         self.rectangleColorValueField.addAction(UIAction(title: ""){_ in
             if let delegate = self.delegate{
-                delegate.updatingSelectedRecntagleViewColorRequested()
+                delegate.updatingSelectedRectangleColorRequested()
             }
         }, for: .touchDown)
     }
@@ -86,7 +79,7 @@ class StylerView: UIView{
     private func setAlphaChangeAction(){
         self.rectangleAlphaSlider.addAction(UIAction(title: ""){ _ in
             if let delegate = self.delegate{
-                delegate.updatingSelectedRectangleViewAlphaRequested(opacity: Int(self.rectangleAlphaSlider.value * 10))
+                delegate.updatingSelectedRectangleAlphaRequested(opacity: Int(self.rectangleAlphaSlider.value * 10))
             }
         }, for: .valueChanged)
     }
@@ -94,9 +87,6 @@ class StylerView: UIView{
     func updateSelectedRectangleViewColorInfo(newColor: UIColor, newHexString: String){
         self.rectangleColorValueField.backgroundColor = newColor
         self.rectangleColorValueField.setTitle(newHexString, for: .normal)
-        if let delegate = self.delegate{
-            delegate.updatingSelectedRectangleViewColorInfoCompleted(newColor: newColor)
-        }
     }
     
 }

--- a/DrawingApp/DrawingApp/View/StylerViewDelegate.swift
+++ b/DrawingApp/DrawingApp/View/StylerViewDelegate.swift
@@ -1,10 +1,11 @@
 import Foundation
+import UIKit
 
 
 protocol StylerViewDelegate: AnyObject{
     func updatingRectangleInfoCompleted()
     func updatingSelectedRectangleViewAlphaRequested(opacity: Int)
     func updatingSelectedRecntagleViewColorRequested()
-    func updatingSelectedRectangleViewColorInfoCompleted(rgb: [Double])
+    func updatingSelectedRectangleViewColorInfoCompleted(newColor: UIColor)
     func clearingSelectedRectangleInfoCompleted()
 }

--- a/DrawingApp/DrawingApp/View/StylerViewDelegate.swift
+++ b/DrawingApp/DrawingApp/View/StylerViewDelegate.swift
@@ -3,9 +3,6 @@ import UIKit
 
 
 protocol StylerViewDelegate: AnyObject{
-    func updatingRectangleInfoCompleted()
-    func updatingSelectedRectangleViewAlphaRequested(opacity: Int)
-    func updatingSelectedRecntagleViewColorRequested()
-    func updatingSelectedRectangleViewColorInfoCompleted(newColor: UIColor)
-    func clearingSelectedRectangleInfoCompleted()
+    func updatingSelectedRectangleAlphaRequested(opacity: Int)
+    func updatingSelectedRectangleColorRequested()
 }


### PR DESCRIPTION
## 작업 내용
- [x] ViewController-Plane 간 NotificationCenter을 사용한 옵저버 패턴 적용 
- [x] Plane에서의 ViewController 참조 제거
- [x] Plane 내부 불필요한 속성, 서브스크립트 제거
    
## 학습키워드
- NotificationCenter
- Observer Pattern
    
## 고민과 해결
### 2단계 리팩토링
- Plane 내부의 불필요한 속성 및 서브스크립트를 제거했습니다.
- __`RectangleViewFactory`__ 를 추가하여 ViewController에서 개별 RectangleView를 만들지 않고 팩토리에서 리턴하는 객체를 서브 뷰로 추가하도록 수정했습니다.
 
### 옵저버 패턴 적용 
- 기존에는 StylerView를 통한 사용자 입력이 들어오면 사용자입력-ViewController-CanvasView-ViewController-StylerView-ViewControllerPlane의 복잡한 과정을 거쳐 순차적으로 입출력이 일어나도록 했지만, __`Observer Pattern`__ 을 적용하여 __`사용자 입력-ViewController-Plane-CanvasView&StylerView`__ 으로 과정을 단순화했습니다.
    - 기존에는 StylerView, CanvasView에서 각각 출력이 완료되면 delegate method를 통해 ViewController에 출력이 끝났음을 알린 후, ViewController가 후속동작으로 Plane의 메소드를 다시 호출하는 식이었지만 __`NotificationCenter`__ 을 사용하여 굳이 delegate method 호출 없이 모델의 값이 변화하면 알아서 ViewController의 메소드를 호출하는 식으로 변경했습니다. 
    - 또한, Plane에서 __`PlaneDelegate`__ 를 통해 모델에서의 값 변경이 끝났음을 ViewController 알리지 않고 미리 등록해둔 옵저버에 알리도록 수정했기에 더 이상 필요 없어진 PlaneDelegate 프로토콜을 없애고 __Plane에서 ViewController을 참조하던 것을 제거했습니다.__
    
### 질문
- 현재 아래와 같은 방식으로 사용자가 CanvasView 상의 어느 한 지점을 터치하면 위와 같이 제스처를 인식하여 사각형 모델 및 뷰를 처리하도록 하고 있는데, 지난 번 피드백에서 이에 대해 __`self.currentlyTouchedView`__ 와 같이 굳이 뷰컨트롤러에 속성을 두지 말고 __`Plane 에서 선택된 Rectangle 모델과 매칭되는 것을 처리`__ 하는 것이 더 낫다고 해주신 부분에 대해 질문이 있습니다.

  ```swift
      func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
          /*
             1. 우선 터치된 곳에 해당하는 touch.view의 타입이 RectangleView인 경우에는,
                현재 터치된 사각형뷰를 임시로 저장한 currentlyTouchedView의 인스턴스로 할당
             2. 이후 Plane에서 터치된 x,y를 가지고 유효한 모델이 내부에 존재하는 지 검증되면 
                 이후 뷰에서 뷰컨트롤러로 값 변경 요청이 들어오면 currentlyTouchedView를 사용하여 사각형 뷰의 배경색 혹은 투명도를 바꿀 수 있도록 함
             4. 단, 이후 터치된 곳에 해당하는 touch.view가 RectangleView가 아닌 경우에는, 
                 사각형이 없는 부분을 터치한 것이므로 currentlyTouchedView를 다시 nil로 초기화
           */
          
          if let touchedView = touch.view as? RectangleView{
              self.currentlyTouchedView = touchedView
          }else{
              self.currentlyTouchedView = nil
          }
          let touchedPoint = touch.location(in: self.canvasView)
          self.plane.findMatchingRectangleModel(x: touchedPoint.x, y: touchedPoint.y)
          return true
      }
  ```
- 위에서 __`currentlyTouchedView`__ 의 경우에는 __`touch.view`__ 가 사실상 __`gestureRecognizer`__ 메소드 내에서만 유효한 인스턴스이기 때문에, 만일 Plane에서 유효한 Rectangle 모델을 찾은 후, 화면을 수정하기 위한 뷰컨트롤러 메소드를 호출했을 때 이를 사용할 수 없어 뷰컨트롤러의 속성값으로 임시로 가지고 있도록 했습니다.
- 지난번 피드백에 대해 제가 이해한 바로는 이런 식으로 속성에 입력값을 두지 않는 것이 좋기 때문에 이를 제거하고 다른 방법을 적용해야 하는 것으로 우선 알고 있는데, 이에 대해  __`touch.view`__ 를 활용하는 것 외에는 뷰에서 터치한 사각형 뷰와 Plane에서 찾은 사각형 모델을 매칭하는 방법이 아직까지 안떠오르는데 혹시 이에 대해 조금 더 힌트를 얻을 수 있을까요?