### PR TITLE
[Pigbag] Step04-1 (Refactory) MainViewController & Rectangle

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -41,6 +41,9 @@
 		8D7593B127DEDE2000F9D8B4 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593B027DEDE2000F9D8B4 /* Image.swift */; };
 		8D7593B627E0AC8A00F9D8B4 /* DrawingAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1AB31327D884550024AD38 /* DrawingAppTests.swift */; };
 		8D7593B827E0AD0F00F9D8B4 /* PlaneRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A827DEDC2E00F9D8B4 /* PlaneRectangle.swift */; };
+		8D7593B927E0BBE300F9D8B4 /* RectangleCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AC27DEDD1E00F9D8B4 /* RectangleCreator.swift */; };
+		8D7593BA27E0BBEE00F9D8B4 /* Rectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A627DEDBAF00F9D8B4 /* Rectangle.swift */; };
+		8D7593BB27E0BBF200F9D8B4 /* RectangleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AE27DEDD5100F9D8B4 /* RectangleFactory.swift */; };
 		8DBC282B27D393A8007422D6 /* UIColor++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBC282A27D393A8007422D6 /* UIColor++.swift */; };
 /* End PBXBuildFile section */
 
@@ -320,6 +323,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8D7593BB27E0BBF200F9D8B4 /* RectangleFactory.swift in Sources */,
+				8D7593BA27E0BBEE00F9D8B4 /* Rectangle.swift in Sources */,
+				8D7593B927E0BBE300F9D8B4 /* RectangleCreator.swift in Sources */,
 				8D7593B827E0AD0F00F9D8B4 /* PlaneRectangle.swift in Sources */,
 				8D7593B627E0AC8A00F9D8B4 /* DrawingAppTests.swift in Sources */,
 				8D1AB32327D9D0A20024AD38 /* IDFactory.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		8D1AB31A27D9CFB50024AD38 /* Plane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5DF31927D0F88300F5E9C5 /* Plane.swift */; };
 		8D1AB31B27D9D0130024AD38 /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083627CE08E900F78A51 /* Size.swift */; };
 		8D1AB31C27D9D01B0024AD38 /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083827CE08F000F78A51 /* Point.swift */; };
-		8D1AB31D27D9D0220024AD38 /* Rectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69082D27CDFDFD00F78A51 /* Rectangle.swift */; };
 		8D1AB31E27D9D0370024AD38 /* RGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083C27CE249900F78A51 /* RGB.swift */; };
 		8D1AB31F27D9D0400024AD38 /* UIColor++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBC282A27D393A8007422D6 /* UIColor++.swift */; };
 		8D1AB32027D9D0680024AD38 /* Alpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083A27CE249200F78A51 /* Alpha.swift */; };
@@ -22,20 +21,25 @@
 		8D5DF31C27D1A88900F5E9C5 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5DF31B27D1A88900F5E9C5 /* DetailView.swift */; };
 		8D5DF32227D3107800F5E9C5 /* DetailViewDelgate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5DF32127D3107800F5E9C5 /* DetailViewDelgate.swift */; };
 		8D67432C27D72AD100397D68 /* RectangleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D67432B27D72AD100397D68 /* RectangleButton.swift */; };
-		8D67432E27D7312200397D68 /* RectangleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D67432D27D7312200397D68 /* RectangleView.swift */; };
+		8D67432E27D7312200397D68 /* PlaneRectangleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D67432D27D7312200397D68 /* PlaneRectangleView.swift */; };
 		8D6907F927CCBEF100F78A51 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6907F827CCBEF100F78A51 /* AppDelegate.swift */; };
 		8D6907FB27CCBEF100F78A51 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6907FA27CCBEF100F78A51 /* SceneDelegate.swift */; };
 		8D6907FD27CCBEF100F78A51 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6907FC27CCBEF100F78A51 /* MainViewController.swift */; };
 		8D69080027CCBEF100F78A51 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D6907FE27CCBEF100F78A51 /* Main.storyboard */; };
 		8D69080227CCBEF400F78A51 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8D69080127CCBEF400F78A51 /* Assets.xcassets */; };
 		8D69080527CCBEF400F78A51 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D69080327CCBEF400F78A51 /* LaunchScreen.storyboard */; };
-		8D69082E27CDFDFD00F78A51 /* Rectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69082D27CDFDFD00F78A51 /* Rectangle.swift */; };
 		8D69083727CE08E900F78A51 /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083627CE08E900F78A51 /* Size.swift */; };
 		8D69083927CE08F000F78A51 /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083827CE08F000F78A51 /* Point.swift */; };
 		8D69083B27CE249200F78A51 /* Alpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083A27CE249200F78A51 /* Alpha.swift */; };
 		8D69083D27CE249900F78A51 /* RGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083C27CE249900F78A51 /* RGB.swift */; };
 		8D69084D27CF4D4200F78A51 /* IDFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69084C27CF4D4200F78A51 /* IDFactory.swift */; };
 		8D69084F27CF4D9F00F78A51 /* ID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69084E27CF4D9F00F78A51 /* ID.swift */; };
+		8D7593A727DEDBAF00F9D8B4 /* Rectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A627DEDBAF00F9D8B4 /* Rectangle.swift */; };
+		8D7593A927DEDC2E00F9D8B4 /* PlaneRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A827DEDC2E00F9D8B4 /* PlaneRectangle.swift */; };
+		8D7593AB27DEDC4100F9D8B4 /* ImageRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AA27DEDC4100F9D8B4 /* ImageRectangle.swift */; };
+		8D7593AD27DEDD1E00F9D8B4 /* RectangleCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AC27DEDD1E00F9D8B4 /* RectangleCreator.swift */; };
+		8D7593AF27DEDD5100F9D8B4 /* RectangleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AE27DEDD5100F9D8B4 /* RectangleFactory.swift */; };
+		8D7593B127DEDE2000F9D8B4 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593B027DEDE2000F9D8B4 /* Image.swift */; };
 		8DBC282B27D393A8007422D6 /* UIColor++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBC282A27D393A8007422D6 /* UIColor++.swift */; };
 /* End PBXBuildFile section */
 
@@ -57,7 +61,7 @@
 		8D5DF31B27D1A88900F5E9C5 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		8D5DF32127D3107800F5E9C5 /* DetailViewDelgate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewDelgate.swift; sourceTree = "<group>"; };
 		8D67432B27D72AD100397D68 /* RectangleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleButton.swift; sourceTree = "<group>"; };
-		8D67432D27D7312200397D68 /* RectangleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RectangleView.swift; sourceTree = "<group>"; };
+		8D67432D27D7312200397D68 /* PlaneRectangleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaneRectangleView.swift; sourceTree = "<group>"; };
 		8D6907F527CCBEF100F78A51 /* DrawingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrawingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D6907F827CCBEF100F78A51 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8D6907FA27CCBEF100F78A51 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -66,13 +70,18 @@
 		8D69080127CCBEF400F78A51 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8D69080427CCBEF400F78A51 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8D69080627CCBEF400F78A51 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8D69082D27CDFDFD00F78A51 /* Rectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rectangle.swift; sourceTree = "<group>"; };
 		8D69083627CE08E900F78A51 /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
 		8D69083827CE08F000F78A51 /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
 		8D69083A27CE249200F78A51 /* Alpha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alpha.swift; sourceTree = "<group>"; };
 		8D69083C27CE249900F78A51 /* RGB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RGB.swift; sourceTree = "<group>"; };
 		8D69084C27CF4D4200F78A51 /* IDFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDFactory.swift; sourceTree = "<group>"; };
 		8D69084E27CF4D9F00F78A51 /* ID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ID.swift; sourceTree = "<group>"; };
+		8D7593A627DEDBAF00F9D8B4 /* Rectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rectangle.swift; sourceTree = "<group>"; };
+		8D7593A827DEDC2E00F9D8B4 /* PlaneRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneRectangle.swift; sourceTree = "<group>"; };
+		8D7593AA27DEDC4100F9D8B4 /* ImageRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRectangle.swift; sourceTree = "<group>"; };
+		8D7593AC27DEDD1E00F9D8B4 /* RectangleCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleCreator.swift; sourceTree = "<group>"; };
+		8D7593AE27DEDD5100F9D8B4 /* RectangleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleFactory.swift; sourceTree = "<group>"; };
+		8D7593B027DEDE2000F9D8B4 /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		8DBC282A27D393A8007422D6 /* UIColor++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor++.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -114,8 +123,10 @@
 			isa = PBXGroup;
 			children = (
 				8D5DF31927D0F88300F5E9C5 /* Plane.swift */,
-				8D69082D27CDFDFD00F78A51 /* Rectangle.swift */,
+				8D7593B027DEDE2000F9D8B4 /* Image.swift */,
 				8D69084E27CF4D9F00F78A51 /* ID.swift */,
+				8D7593A827DEDC2E00F9D8B4 /* PlaneRectangle.swift */,
+				8D7593AA27DEDC4100F9D8B4 /* ImageRectangle.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -181,6 +192,7 @@
 			isa = PBXGroup;
 			children = (
 				8D69084C27CF4D4200F78A51 /* IDFactory.swift */,
+				8D7593AE27DEDD5100F9D8B4 /* RectangleFactory.swift */,
 			);
 			path = Factory;
 			sourceTree = "<group>";
@@ -191,7 +203,7 @@
 				8D67432B27D72AD100397D68 /* RectangleButton.swift */,
 				8D41425F27DB2AB30070FDCB /* ImageButton.swift */,
 				8D5DF31B27D1A88900F5E9C5 /* DetailView.swift */,
-				8D67432D27D7312200397D68 /* RectangleView.swift */,
+				8D67432D27D7312200397D68 /* PlaneRectangleView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -200,6 +212,8 @@
 			isa = PBXGroup;
 			children = (
 				8D5DF32127D3107800F5E9C5 /* DetailViewDelgate.swift */,
+				8D7593A627DEDBAF00F9D8B4 /* Rectangle.swift */,
+				8D7593AC27DEDD1E00F9D8B4 /* RectangleCreator.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -310,7 +324,6 @@
 				8D1AB32027D9D0680024AD38 /* Alpha.swift in Sources */,
 				8D1AB31F27D9D0400024AD38 /* UIColor++.swift in Sources */,
 				8D1AB31E27D9D0370024AD38 /* RGB.swift in Sources */,
-				8D1AB31D27D9D0220024AD38 /* Rectangle.swift in Sources */,
 				8D1AB31C27D9D01B0024AD38 /* Point.swift in Sources */,
 				8D1AB31B27D9D0130024AD38 /* Size.swift in Sources */,
 				8D1AB31A27D9CFB50024AD38 /* Plane.swift in Sources */,
@@ -324,21 +337,26 @@
 			files = (
 				8D41426027DB2AB30070FDCB /* ImageButton.swift in Sources */,
 				8D6907FD27CCBEF100F78A51 /* MainViewController.swift in Sources */,
+				8D7593B127DEDE2000F9D8B4 /* Image.swift in Sources */,
+				8D7593AD27DEDD1E00F9D8B4 /* RectangleCreator.swift in Sources */,
 				8D5DF31C27D1A88900F5E9C5 /* DetailView.swift in Sources */,
+				8D7593A927DEDC2E00F9D8B4 /* PlaneRectangle.swift in Sources */,
 				8D69083727CE08E900F78A51 /* Size.swift in Sources */,
 				8D69083B27CE249200F78A51 /* Alpha.swift in Sources */,
 				8D69083927CE08F000F78A51 /* Point.swift in Sources */,
-				8D67432E27D7312200397D68 /* RectangleView.swift in Sources */,
+				8D67432E27D7312200397D68 /* PlaneRectangleView.swift in Sources */,
 				8D5DF31A27D0F88300F5E9C5 /* Plane.swift in Sources */,
+				8D7593AF27DEDD5100F9D8B4 /* RectangleFactory.swift in Sources */,
 				8D6907F927CCBEF100F78A51 /* AppDelegate.swift in Sources */,
 				8D69084F27CF4D9F00F78A51 /* ID.swift in Sources */,
 				8D67432C27D72AD100397D68 /* RectangleButton.swift in Sources */,
 				8D6907FB27CCBEF100F78A51 /* SceneDelegate.swift in Sources */,
 				8D69084D27CF4D4200F78A51 /* IDFactory.swift in Sources */,
+				8D7593A727DEDBAF00F9D8B4 /* Rectangle.swift in Sources */,
 				8DBC282B27D393A8007422D6 /* UIColor++.swift in Sources */,
-				8D69082E27CDFDFD00F78A51 /* Rectangle.swift in Sources */,
 				8D5DF32227D3107800F5E9C5 /* DetailViewDelgate.swift in Sources */,
 				8D69083D27CE249900F78A51 /* RGB.swift in Sources */,
+				8D7593AB27DEDC4100F9D8B4 /* ImageRectangle.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		8D1AB32027D9D0680024AD38 /* Alpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083A27CE249200F78A51 /* Alpha.swift */; };
 		8D1AB32227D9D09F0024AD38 /* ID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69084E27CF4D9F00F78A51 /* ID.swift */; };
 		8D1AB32327D9D0A20024AD38 /* IDFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69084C27CF4D4200F78A51 /* IDFactory.swift */; };
+		8D41426027DB2AB30070FDCB /* ImageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D41425F27DB2AB30070FDCB /* ImageButton.swift */; };
 		8D5DF31A27D0F88300F5E9C5 /* Plane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5DF31927D0F88300F5E9C5 /* Plane.swift */; };
 		8D5DF31C27D1A88900F5E9C5 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5DF31B27D1A88900F5E9C5 /* DetailView.swift */; };
 		8D5DF32227D3107800F5E9C5 /* DetailViewDelgate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5DF32127D3107800F5E9C5 /* DetailViewDelgate.swift */; };
@@ -51,6 +52,7 @@
 /* Begin PBXFileReference section */
 		8D1AB31127D884550024AD38 /* DrawingAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DrawingAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D1AB31327D884550024AD38 /* DrawingAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingAppTests.swift; sourceTree = "<group>"; };
+		8D41425F27DB2AB30070FDCB /* ImageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageButton.swift; sourceTree = "<group>"; };
 		8D5DF31927D0F88300F5E9C5 /* Plane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plane.swift; sourceTree = "<group>"; };
 		8D5DF31B27D1A88900F5E9C5 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		8D5DF32127D3107800F5E9C5 /* DetailViewDelgate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewDelgate.swift; sourceTree = "<group>"; };
@@ -187,6 +189,7 @@
 			isa = PBXGroup;
 			children = (
 				8D67432B27D72AD100397D68 /* RectangleButton.swift */,
+				8D41425F27DB2AB30070FDCB /* ImageButton.swift */,
 				8D5DF31B27D1A88900F5E9C5 /* DetailView.swift */,
 				8D67432D27D7312200397D68 /* RectangleView.swift */,
 			);
@@ -319,6 +322,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8D41426027DB2AB30070FDCB /* ImageButton.swift in Sources */,
 				8D6907FD27CCBEF100F78A51 /* MainViewController.swift in Sources */,
 				8D5DF31C27D1A88900F5E9C5 /* DetailView.swift in Sources */,
 				8D69083727CE08E900F78A51 /* Size.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		8D1AB31427D884550024AD38 /* DrawingAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1AB31327D884550024AD38 /* DrawingAppTests.swift */; };
 		8D1AB31A27D9CFB50024AD38 /* Plane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5DF31927D0F88300F5E9C5 /* Plane.swift */; };
 		8D1AB31B27D9D0130024AD38 /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083627CE08E900F78A51 /* Size.swift */; };
 		8D1AB31C27D9D01B0024AD38 /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083827CE08F000F78A51 /* Point.swift */; };
@@ -40,6 +39,8 @@
 		8D7593AD27DEDD1E00F9D8B4 /* RectangleCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AC27DEDD1E00F9D8B4 /* RectangleCreator.swift */; };
 		8D7593AF27DEDD5100F9D8B4 /* RectangleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AE27DEDD5100F9D8B4 /* RectangleFactory.swift */; };
 		8D7593B127DEDE2000F9D8B4 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593B027DEDE2000F9D8B4 /* Image.swift */; };
+		8D7593B627E0AC8A00F9D8B4 /* DrawingAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1AB31327D884550024AD38 /* DrawingAppTests.swift */; };
+		8D7593B827E0AD0F00F9D8B4 /* PlaneRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A827DEDC2E00F9D8B4 /* PlaneRectangle.swift */; };
 		8DBC282B27D393A8007422D6 /* UIColor++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBC282A27D393A8007422D6 /* UIColor++.swift */; };
 /* End PBXBuildFile section */
 
@@ -319,6 +320,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8D7593B827E0AD0F00F9D8B4 /* PlaneRectangle.swift in Sources */,
+				8D7593B627E0AC8A00F9D8B4 /* DrawingAppTests.swift in Sources */,
 				8D1AB32327D9D0A20024AD38 /* IDFactory.swift in Sources */,
 				8D1AB32227D9D09F0024AD38 /* ID.swift in Sources */,
 				8D1AB32027D9D0680024AD38 /* Alpha.swift in Sources */,
@@ -327,7 +330,6 @@
 				8D1AB31C27D9D01B0024AD38 /* Point.swift in Sources */,
 				8D1AB31B27D9D0130024AD38 /* Size.swift in Sources */,
 				8D1AB31A27D9CFB50024AD38 /* Plane.swift in Sources */,
-				8D1AB31427D884550024AD38 /* DrawingAppTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		8D69083D27CE249900F78A51 /* RGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69083C27CE249900F78A51 /* RGB.swift */; };
 		8D69084D27CF4D4200F78A51 /* IDFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69084C27CF4D4200F78A51 /* IDFactory.swift */; };
 		8D69084F27CF4D9F00F78A51 /* ID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69084E27CF4D9F00F78A51 /* ID.swift */; };
-		8D7593A727DEDBAF00F9D8B4 /* Rectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A627DEDBAF00F9D8B4 /* Rectangle.swift */; };
+		8D7593A727DEDBAF00F9D8B4 /* Rectangleable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A627DEDBAF00F9D8B4 /* Rectangleable.swift */; };
 		8D7593A927DEDC2E00F9D8B4 /* PlaneRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A827DEDC2E00F9D8B4 /* PlaneRectangle.swift */; };
 		8D7593AB27DEDC4100F9D8B4 /* ImageRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AA27DEDC4100F9D8B4 /* ImageRectangle.swift */; };
 		8D7593AD27DEDD1E00F9D8B4 /* RectangleCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AC27DEDD1E00F9D8B4 /* RectangleCreator.swift */; };
@@ -42,8 +42,12 @@
 		8D7593B627E0AC8A00F9D8B4 /* DrawingAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1AB31327D884550024AD38 /* DrawingAppTests.swift */; };
 		8D7593B827E0AD0F00F9D8B4 /* PlaneRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A827DEDC2E00F9D8B4 /* PlaneRectangle.swift */; };
 		8D7593B927E0BBE300F9D8B4 /* RectangleCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AC27DEDD1E00F9D8B4 /* RectangleCreator.swift */; };
-		8D7593BA27E0BBEE00F9D8B4 /* Rectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A627DEDBAF00F9D8B4 /* Rectangle.swift */; };
+		8D7593BA27E0BBEE00F9D8B4 /* Rectangleable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593A627DEDBAF00F9D8B4 /* Rectangleable.swift */; };
 		8D7593BB27E0BBF200F9D8B4 /* RectangleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593AE27DEDD5100F9D8B4 /* RectangleFactory.swift */; };
+		8D7593BD27E0CAC800F9D8B4 /* RectanlgeViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593BC27E0CAC800F9D8B4 /* RectanlgeViewFactory.swift */; };
+		8D7593BF27E0CAF100F9D8B4 /* RectangleViewCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593BE27E0CAF100F9D8B4 /* RectangleViewCreator.swift */; };
+		8D7593C327E189AA00F9D8B4 /* RectangleViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593C227E189AA00F9D8B4 /* RectangleViewable.swift */; };
+		8D7593C527E18B9D00F9D8B4 /* ImageRectangleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7593C427E18B9D00F9D8B4 /* ImageRectangleView.swift */; };
 		8DBC282B27D393A8007422D6 /* UIColor++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBC282A27D393A8007422D6 /* UIColor++.swift */; };
 /* End PBXBuildFile section */
 
@@ -80,12 +84,16 @@
 		8D69083C27CE249900F78A51 /* RGB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RGB.swift; sourceTree = "<group>"; };
 		8D69084C27CF4D4200F78A51 /* IDFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDFactory.swift; sourceTree = "<group>"; };
 		8D69084E27CF4D9F00F78A51 /* ID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ID.swift; sourceTree = "<group>"; };
-		8D7593A627DEDBAF00F9D8B4 /* Rectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rectangle.swift; sourceTree = "<group>"; };
+		8D7593A627DEDBAF00F9D8B4 /* Rectangleable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rectangleable.swift; sourceTree = "<group>"; };
 		8D7593A827DEDC2E00F9D8B4 /* PlaneRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneRectangle.swift; sourceTree = "<group>"; };
 		8D7593AA27DEDC4100F9D8B4 /* ImageRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRectangle.swift; sourceTree = "<group>"; };
 		8D7593AC27DEDD1E00F9D8B4 /* RectangleCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleCreator.swift; sourceTree = "<group>"; };
 		8D7593AE27DEDD5100F9D8B4 /* RectangleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleFactory.swift; sourceTree = "<group>"; };
 		8D7593B027DEDE2000F9D8B4 /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
+		8D7593BC27E0CAC800F9D8B4 /* RectanlgeViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectanlgeViewFactory.swift; sourceTree = "<group>"; };
+		8D7593BE27E0CAF100F9D8B4 /* RectangleViewCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleViewCreator.swift; sourceTree = "<group>"; };
+		8D7593C227E189AA00F9D8B4 /* RectangleViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleViewable.swift; sourceTree = "<group>"; };
+		8D7593C427E18B9D00F9D8B4 /* ImageRectangleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRectangleView.swift; sourceTree = "<group>"; };
 		8DBC282A27D393A8007422D6 /* UIColor++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor++.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -197,6 +205,7 @@
 			children = (
 				8D69084C27CF4D4200F78A51 /* IDFactory.swift */,
 				8D7593AE27DEDD5100F9D8B4 /* RectangleFactory.swift */,
+				8D7593BC27E0CAC800F9D8B4 /* RectanlgeViewFactory.swift */,
 			);
 			path = Factory;
 			sourceTree = "<group>";
@@ -208,6 +217,7 @@
 				8D41425F27DB2AB30070FDCB /* ImageButton.swift */,
 				8D5DF31B27D1A88900F5E9C5 /* DetailView.swift */,
 				8D67432D27D7312200397D68 /* PlaneRectangleView.swift */,
+				8D7593C427E18B9D00F9D8B4 /* ImageRectangleView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -216,8 +226,10 @@
 			isa = PBXGroup;
 			children = (
 				8D5DF32127D3107800F5E9C5 /* DetailViewDelgate.swift */,
-				8D7593A627DEDBAF00F9D8B4 /* Rectangle.swift */,
+				8D7593A627DEDBAF00F9D8B4 /* Rectangleable.swift */,
+				8D7593C227E189AA00F9D8B4 /* RectangleViewable.swift */,
 				8D7593AC27DEDD1E00F9D8B4 /* RectangleCreator.swift */,
+				8D7593BE27E0CAF100F9D8B4 /* RectangleViewCreator.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -324,7 +336,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8D7593BB27E0BBF200F9D8B4 /* RectangleFactory.swift in Sources */,
-				8D7593BA27E0BBEE00F9D8B4 /* Rectangle.swift in Sources */,
+				8D7593BA27E0BBEE00F9D8B4 /* Rectangleable.swift in Sources */,
 				8D7593B927E0BBE300F9D8B4 /* RectangleCreator.swift in Sources */,
 				8D7593B827E0AD0F00F9D8B4 /* PlaneRectangle.swift in Sources */,
 				8D7593B627E0AC8A00F9D8B4 /* DrawingAppTests.swift in Sources */,
@@ -351,18 +363,22 @@
 				8D7593A927DEDC2E00F9D8B4 /* PlaneRectangle.swift in Sources */,
 				8D69083727CE08E900F78A51 /* Size.swift in Sources */,
 				8D69083B27CE249200F78A51 /* Alpha.swift in Sources */,
+				8D7593C527E18B9D00F9D8B4 /* ImageRectangleView.swift in Sources */,
 				8D69083927CE08F000F78A51 /* Point.swift in Sources */,
 				8D67432E27D7312200397D68 /* PlaneRectangleView.swift in Sources */,
 				8D5DF31A27D0F88300F5E9C5 /* Plane.swift in Sources */,
 				8D7593AF27DEDD5100F9D8B4 /* RectangleFactory.swift in Sources */,
 				8D6907F927CCBEF100F78A51 /* AppDelegate.swift in Sources */,
 				8D69084F27CF4D9F00F78A51 /* ID.swift in Sources */,
+				8D7593BD27E0CAC800F9D8B4 /* RectanlgeViewFactory.swift in Sources */,
 				8D67432C27D72AD100397D68 /* RectangleButton.swift in Sources */,
 				8D6907FB27CCBEF100F78A51 /* SceneDelegate.swift in Sources */,
 				8D69084D27CF4D4200F78A51 /* IDFactory.swift in Sources */,
-				8D7593A727DEDBAF00F9D8B4 /* Rectangle.swift in Sources */,
+				8D7593A727DEDBAF00F9D8B4 /* Rectangleable.swift in Sources */,
+				8D7593C327E189AA00F9D8B4 /* RectangleViewable.swift in Sources */,
 				8DBC282B27D393A8007422D6 /* UIColor++.swift in Sources */,
 				8D5DF32227D3107800F5E9C5 /* DetailViewDelgate.swift in Sources */,
+				8D7593BF27E0CAF100F9D8B4 /* RectangleViewCreator.swift in Sources */,
 				8D69083D27CE249900F78A51 /* RGB.swift in Sources */,
 				8D7593AB27DEDC4100F9D8B4 /* ImageRectangle.swift in Sources */,
 			);

--- a/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
@@ -5,11 +5,10 @@
 //  Created by 박진섭 on 2022/03/14.
 //
 
-
 //Image가 들어가있는 Rectangle, 기본 plane Rectangle들을 Rectangle로 묶어서 Factory메서드를 사용할수 있을것 같아 선언
 final class RectangleFactory:RectangleCreator {
     
-    func makeRectangle(type:Rectangle.Type) -> Rectangle {
+    func makeRectangle(type:Rectangleable.Type) -> Rectangleable {
         let id = IDFactory.makeRandomID()
         let size = Size(width: 150, height: 120)
         let origin = Point.random()

--- a/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
@@ -5,27 +5,23 @@
 //  Created by 박진섭 on 2022/03/14.
 //
 
-final class RectangleFactory:RectangleCreator {
+
+//Image가 들어가있는 Rectangle, 기본 plane Rectangle들을 Rectangle로 묶어서 Factory메서드를 사용할수 있을것 같아 선언했습니다.
+final class RectangleFactory {
     
-    func makePlaneRectangle() -> PlaneRectangle {
+    func makeRectangle(type:Rectangle.Type) -> Rectangle {
         let id = IDFactory.makeRandomID()
         let size = Size(width: 150, height: 120)
-        let point = Point.random()
+        let origin = Point.random()
         let rgb = RGB.random()
         let alpha = Alpha.random()
         
-        let rect = PlaneRectangle(id: id, origin: point, size: size, backGroundColor: rgb, alpha: alpha)
-        
-        return rect
-    }
-    
-    func makeImageRectangle() -> ImageRectangle {
-        let id = IDFactory.makeRandomID()
-        let size = Size(width: 150, height: 120)
-        let point = Point.random()
-        let alpha = Alpha.random()
-        
-        let rect = ImageRectangle(id: id, origin: point, size: size, alpha: alpha)
-        return rect
+        //PlaneRectangle은 가장 기본이 되는 Rectangle로 생각하여 default값으로 두고 type을 처리했습니다.
+        switch ObjectIdentifier(type) {
+        case ObjectIdentifier(ImageRectangle.self):
+            return ImageRectangle(id: id, origin: origin, size: size, rgb: rgb, alpha: alpha)
+        default:
+            return PlaneRectangle(id: id, origin: origin, size: size, rgb: rgb, alpha: alpha)
+        }
     }
 }

--- a/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
@@ -16,12 +16,7 @@ final class RectangleFactory:RectangleCreator {
         let rgb = RGB.random()
         let alpha = Alpha.random()
         
-        //PlaneRectangle은 가장 기본이 되는 Rectangle로 생각하여 default값으로 두고 type을 처리
-        switch ObjectIdentifier(type) {
-        case ObjectIdentifier(ImageRectangle.self):
-            return ImageRectangle(id: id, origin: origin, size: size, alpha: alpha)
-        default:
-            return PlaneRectangle(id: id, origin: origin, size: size, rgb: rgb, alpha: alpha)
-        }
+        //type에 따라 init
+        return type.init(id: id, origin: origin, size: size, rgb: rgb, alpha: alpha)
     }
 }

--- a/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
@@ -6,7 +6,7 @@
 //
 
 
-//Image가 들어가있는 Rectangle, 기본 plane Rectangle들을 Rectangle로 묶어서 Factory메서드를 사용할수 있을것 같아 선언했습니다.
+//Image가 들어가있는 Rectangle, 기본 plane Rectangle들을 Rectangle로 묶어서 Factory메서드를 사용할수 있을것 같아 선언
 final class RectangleFactory:RectangleCreator {
     
     func makeRectangle(type:Rectangle.Type) -> Rectangle {
@@ -16,10 +16,10 @@ final class RectangleFactory:RectangleCreator {
         let rgb = RGB.random()
         let alpha = Alpha.random()
         
-        //PlaneRectangle은 가장 기본이 되는 Rectangle로 생각하여 default값으로 두고 type을 처리했습니다.
+        //PlaneRectangle은 가장 기본이 되는 Rectangle로 생각하여 default값으로 두고 type을 처리
         switch ObjectIdentifier(type) {
         case ObjectIdentifier(ImageRectangle.self):
-            return ImageRectangle(id: id, origin: origin, size: size, rgb: rgb, alpha: alpha)
+            return ImageRectangle(id: id, origin: origin, size: size, alpha: alpha)
         default:
             return PlaneRectangle(id: id, origin: origin, size: size, rgb: rgb, alpha: alpha)
         }

--- a/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
@@ -1,0 +1,31 @@
+//
+//  RectangleFactory.swift
+//  DrawingApp
+//
+//  Created by 박진섭 on 2022/03/14.
+//
+
+final class RectangleFactory:RectangleCreator {
+    
+    func makePlaneRectangle() -> PlaneRectangle {
+        let id = IDFactory.makeRandomID()
+        let size = Size(width: 150, height: 120)
+        let point = Point.random()
+        let rgb = RGB.random()
+        let alpha = Alpha.random()
+        
+        let rect = PlaneRectangle(id: id, origin: point, size: size, backGroundColor: rgb, alpha: alpha)
+        
+        return rect
+    }
+    
+    func makeImageRectangle() -> ImageRectangle {
+        let id = IDFactory.makeRandomID()
+        let size = Size(width: 150, height: 120)
+        let point = Point.random()
+        let alpha = Alpha.random()
+        
+        let rect = ImageRectangle(id: id, origin: point, size: size, alpha: alpha)
+        return rect
+    }
+}

--- a/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Factory/RectangleFactory.swift
@@ -7,7 +7,7 @@
 
 
 //Image가 들어가있는 Rectangle, 기본 plane Rectangle들을 Rectangle로 묶어서 Factory메서드를 사용할수 있을것 같아 선언했습니다.
-final class RectangleFactory {
+final class RectangleFactory:RectangleCreator {
     
     func makeRectangle(type:Rectangle.Type) -> Rectangle {
         let id = IDFactory.makeRandomID()

--- a/DrawingApp/DrawingApp/Factory/RectanlgeViewFactory.swift
+++ b/DrawingApp/DrawingApp/Factory/RectanlgeViewFactory.swift
@@ -1,0 +1,8 @@
+//
+//  RectanlgeViewFactory.swift
+//  DrawingApp
+//
+//  Created by 박진섭 on 2022/03/15.
+//
+
+import Foundation

--- a/DrawingApp/DrawingApp/Factory/RectanlgeViewFactory.swift
+++ b/DrawingApp/DrawingApp/Factory/RectanlgeViewFactory.swift
@@ -5,4 +5,20 @@
 //  Created by 박진섭 on 2022/03/15.
 //
 
-import Foundation
+final class RectanlgeViewFactory:RectangleViewCreator {
+    static func makeRectangleView(sourceRectangle: Rectangleable) -> RectangleViewable {
+        switch type(of: sourceRectangle) {
+        case is ImageRectangle:
+            let rectangle = ImageRectanlgeView(frame:.zero)
+            rectangle.setupFrameWithRectangle(rect: sourceRectangle)
+            return rectangle
+        default:
+            let source = sourceRectangle as! PlaneRectangle
+            let rectangle = PlaneRectangleView()
+            rectangle.setupFrameWithRectangle(rect: sourceRectangle)
+            rectangle.setupBackGroundColor(rgb: source.rgb ?? RGB(red: 0, green: 0, blue: 0), alpha: source.alpha ?? Alpha(1.0))
+            return rectangle
+        }
+        
+    }
+}

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -16,14 +16,16 @@ final class MainViewController: UIViewController{
     private var detailView = DetailView(frame: .zero)       //생성시 오해를 막고 기존 생성자와 관련있게 하기 위해 frame에 .zero를 대입했습니다.
     private var rectangleButton:UIButton = RectangleButton(frame: .zero)
     private var imageButton:UIButton = ImageButton(frame: .zero)
+    //Factory
+    private let rectangleFactory = RectangleFactory()
     
-    //그려진 retangleView를 모델(Rectangle)을 Key로 찾는 Dictionary로 만들어서 모델과 매칭을 시켜주었습니다.
-    private var retangleViews = [Rectangle:RectangleView]()
-    //선택된 rectangleView
-    private var seletedRectangleView:RectangleView?
+    //그려진 PlaneRetangleView를 모델(Rectangle)을 Key로 찾는 Dictionary로 만들어서 모델과 매칭을 시켜주었습니다.
+    private var retangleViews = [PlaneRectangle:PlaneRectangleView]()
+    //선택된 PlaneRectangleView
+    private var seletedRectangleView:PlaneRectangleView?
     
     private let imagePicker = UIImagePickerController()
-    
+
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -64,15 +66,16 @@ final class MainViewController: UIViewController{
         
         imageButton.layer.zPosition = 1.0
         imageButton.frame = CGRect(x: x, y: y, width: width, height: height)
-//        imageButton.addAction(imageInputToView(), for: .touchUpInside)
+        imageButton.addAction(addImageRectangleAction(), for: .touchUpInside)
     }
     
-//    private func imageInputToView() -> UIAction {
-//        let action:UIAction = { _ in
-//
-//        }
-//        return action
-//    }
+    private func addImageRectangleAction() -> UIAction {
+        let action = UIAction {[weak self] _ in
+            guard let rect = self?.rectangleFactory.makePlaneRectangle() else { return }
+            self?.plane.addRectangle(rectangle: rect)    //모델에 rectangle을 추가
+        }
+        return action
+    }
     
     
     //사각형 추가 버튼 Frame정의 및 Action추가.
@@ -90,16 +93,9 @@ final class MainViewController: UIViewController{
     
     //버튼 액션 - 사각형 추가
     private func addRectangleAction() -> UIAction {
-        let action = UIAction {_ in
-            let id = IDFactory.makeRandomID()
-            let size = Size(width: 150, height: 120)
-            let point = Point.random()
-            let rgb = RGB.random()
-            let alpha = Alpha.random()
-            
-            let rect = Rectangle(id: id, origin: point, size: size, backGroundColor: rgb, alpha: alpha)
-            
-            self.plane.addRectangle(rectangle: rect)    //모델에 rectangle을 추가
+        let action = UIAction {[weak self] _ in
+            guard let rect = self?.rectangleFactory.makePlaneRectangle() else { return }
+            self?.plane.addRectangle(rectangle: rect)    //모델에 rectangle을 추가
         }
         return action
     }
@@ -175,9 +171,9 @@ extension MainViewController:UIGestureRecognizerDelegate {
     
     //addRectagnleView
     @objc func addRectangleView(_ notification:Notification) {
-        guard let newRectangle = notification.userInfo?[Plane.UserInfoKey.addedRectangle] as? Rectangle else { return }
+        guard let newRectangle = notification.userInfo?[Plane.UserInfoKey.addedRectangle] as? PlaneRectangle else { return }
         
-        let rectangleView = RectangleView(rect: newRectangle, rgb: newRectangle.rgb, alpha: newRectangle.alpha)
+        let rectangleView = PlaneRectangleView(rect: newRectangle, rgb: newRectangle.rgb, alpha: newRectangle.alpha)
         view.addSubview(rectangleView)
         
         self.retangleViews[newRectangle] = rectangleView
@@ -190,7 +186,7 @@ extension MainViewController:UIGestureRecognizerDelegate {
     @objc func findSelectedRectangle(_ notification:Notification) {
         seletedRectangleView?.layer.borderWidth = .zero
         
-        guard let seletedRectangle = notification.userInfo?[Plane.UserInfoKey.foundRectangle] as? Rectangle else { return }
+        guard let seletedRectangle = notification.userInfo?[Plane.UserInfoKey.foundRectangle] as? PlaneRectangle else { return }
         
         let rectangleView = self.retangleViews[seletedRectangle]
         self.seletedRectangleView = rectangleView

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -22,9 +22,6 @@ final class MainViewController: UIViewController{
     //선택된 PlaneRectangleView
     private var seletedRectangleView:PlaneRectangleView?
     
-    //factory
-    private var rectanagleCreator:RectangleCreator? = nil
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -36,12 +33,6 @@ final class MainViewController: UIViewController{
         configureTapGesture()
         addViews()
     }
-    
-    //Factory setup
-    private func setupRectangleFactory(creator:RectangleCreator) {
-        self.rectanagleCreator = creator
-    }
-    
     
     //TapGesture
     private func configureTapGesture() {
@@ -88,10 +79,8 @@ final class MainViewController: UIViewController{
     
     //버튼 액션 - 사각형 추가
     private func addRectangleAction(rectangleCreator:RectangleCreator) -> UIAction {
-        setupRectangleFactory(creator:rectangleCreator)
         let action = UIAction {[weak self] _ in
-            let rect = self?.rectanagleCreator?.makeRectangle(type: PlaneRectangle.self)
-            self?.plane.addRectangle(rectangle: rect as! PlaneRectangle)    //모델에 rectangle을 추가
+            self?.plane.addRectangle(creator: rectangleCreator)
         }
         return action
     }

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -14,19 +14,22 @@ final class MainViewController: UIViewController{
     private var plane = Plane()
     //view
     private var detailView = DetailView(frame: .zero)       //생성시 오해를 막고 기존 생성자와 관련있게 하기 위해 frame에 .zero를 대입했습니다.
-    private var button:UIButton = RectangleButton(frame: .zero)
+    private var rectangleButton:UIButton = RectangleButton(frame: .zero)
+    private var imageButton:UIButton = ImageButton(frame: .zero)
     
     //그려진 retangleView를 모델(Rectangle)을 Key로 찾는 Dictionary로 만들어서 모델과 매칭을 시켜주었습니다.
     private var retangleViews = [Rectangle:RectangleView]()
     //선택된 rectangleView
     private var seletedRectangleView:RectangleView?
     
+    private let imagePicker = UIImagePickerController()
     
     
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNotificationCenter()
         
+        configureImageButton()
         configureRectangleButton()
         configureDeatailView()
         configureTapGesture()
@@ -53,6 +56,25 @@ final class MainViewController: UIViewController{
         )
     }
     
+    private func configureImageButton() {
+        let width = 150.0
+        let height = 100.0
+        let x:CGFloat = (self.view.frame.maxX / 2.0) - (width / 2) - width
+        let y:CGFloat = (self.view.frame.maxY - height)
+        
+        imageButton.layer.zPosition = 1.0
+        imageButton.frame = CGRect(x: x, y: y, width: width, height: height)
+//        imageButton.addAction(imageInputToView(), for: .touchUpInside)
+    }
+    
+//    private func imageInputToView() -> UIAction {
+//        let action:UIAction = { _ in
+//
+//        }
+//        return action
+//    }
+    
+    
     //사각형 추가 버튼 Frame정의 및 Action추가.
     private func configureRectangleButton() {
         let width = 150.0
@@ -60,13 +82,14 @@ final class MainViewController: UIViewController{
         let x:CGFloat = (self.view.frame.maxX / 2.0) - (width / 2)
         let y:CGFloat = (self.view.frame.maxY - height)
         
-        button.layer.zPosition = 1.0                                //생성되는 사각형에 겹쳐서 안보이는 경우를 막기위해 zPosition을 주었다.
-        button.frame = CGRect(x: x, y: y, width: width, height: height)
-        button.addAction(makeAddRectangleAction(), for: .touchUpInside)
+        rectangleButton.layer.zPosition = 1.0                                //생성되는 사각형에 겹쳐서 안보이는 경우를 막기위해 zPosition을 주었다.
+        
+        rectangleButton.frame = CGRect(x: x, y: y, width: width, height: height)
+        rectangleButton.addAction(addRectangleAction(), for: .touchUpInside)
     }
     
     //버튼 액션 - 사각형 추가
-    private func makeAddRectangleAction() -> UIAction {
+    private func addRectangleAction() -> UIAction {
         let action = UIAction {_ in
             let id = IDFactory.makeRandomID()
             let size = Size(width: 150, height: 120)
@@ -83,8 +106,9 @@ final class MainViewController: UIViewController{
     
     //Custom View추가
     private func addViews() {
-        view.addSubview(button)
+        view.addSubview(rectangleButton)
         view.addSubview(detailView)
+        view.addSubview(imageButton)
     }
 }
 
@@ -158,7 +182,7 @@ extension MainViewController:UIGestureRecognizerDelegate {
         
         self.retangleViews[newRectangle] = rectangleView
         
-        self.view.bringSubviewToFront(button)
+        self.view.bringSubviewToFront(rectangleButton)
         self.view.bringSubviewToFront(detailView)
     }
     
@@ -180,10 +204,6 @@ extension MainViewController:UIGestureRecognizerDelegate {
         self.detailView.backgroundColorButton.setTitle("\(seletedRectangle.rgb.hexValue)", for: .normal)
     }
 }
-
-
-
-
 
 //MARK: -- DetailViewDelegate
 //슬라이더를 움직일때 마다 현재 클릭한 모델 사각형의 alpha값을 바꾼다.

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -10,9 +10,6 @@ import OSLog
 
 final class MainViewController: UIViewController{
     
-    //NotificationCenter.default가 중복되는것 같아 private 상수로 선언했습니다.
-    private let defultNotificationCenter = NotificationCenter.default
-    
     //model
     private var plane = Plane()
     //view
@@ -109,25 +106,25 @@ extension MainViewController:UIGestureRecognizerDelegate {
     
     //MARK: -- NotificationCenter
     private func configureNotificationCenter() {
-        defultNotificationCenter.addObserver(
+        NotificationCenter.default.addObserver(
             self,
             selector:#selector(addRectangleView),
             name: Plane.NotificationName.didAddRectangle,
             object: plane )
         
-        defultNotificationCenter.addObserver(
+        NotificationCenter.default.addObserver(
             self,
             selector: #selector(findSelectedRectangle),
             name: Plane.NotificationName.didFindRectangle,
             object: plane )
         
-        defultNotificationCenter.addObserver(
+        NotificationCenter.default.addObserver(
             self,
             selector: #selector(changeAlpha),
             name: Plane.NotificationName.didchangeRectangleAlpha,
             object: plane )
         
-        defultNotificationCenter.addObserver(
+        NotificationCenter.default.addObserver(
             self,
             selector: #selector(changeColor),
             name: Plane.NotificationName.didChangeRectangleColor,

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -98,7 +98,8 @@ extension MainViewController:UIGestureRecognizerDelegate {
         //Plane에게 touch된 View의 origin좌표를 넘겨준다.
         let x:Double = touchedView.frame.origin.x
         let y:Double = touchedView.frame.origin.y
-        plane.findSeletedRectangle(x: x, y: y)
+        let size:Size = Size(width: touchedView.frame.size.width, height: touchedView.frame.size.height)
+        plane.findSeletedRectangle(x: x, y: y, size: size)
         
         return true
     }

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -157,12 +157,11 @@ extension MainViewController:UIGestureRecognizerDelegate {
     //addRectagnleView
     @objc func addRectangleView(_ notification:Notification) {
         guard let newRectangle = notification.userInfo?[Plane.UserInfoKey.addedRectangle] as? PlaneRectangle else { return }
-        
-        let rectangleView = PlaneRectangleView(rect: newRectangle, rgb: newRectangle.rgb, alpha: newRectangle.alpha)
-        view.addSubview(rectangleView)
+        guard let rectangleView = RectanlgeViewFactory.makeRectangleView(sourceRectangle: newRectangle) as? PlaneRectangleView else { return }
         
         self.retangleViews[newRectangle] = rectangleView
         
+        view.addSubview(rectangleView)
         self.view.bringSubviewToFront(rectangleButton)
         self.view.bringSubviewToFront(detailView)
     }
@@ -179,10 +178,10 @@ extension MainViewController:UIGestureRecognizerDelegate {
         seletedRectangleView?.layer.borderWidth = 2.0
         seletedRectangleView?.layer.borderColor = UIColor.blue.cgColor
         
-        self.detailView.alphaLabel.text = "\(seletedRectangle.alpha.value)"
-        self.detailView.alphaSlider.value = seletedRectangle.alpha.value
+        self.detailView.alphaLabel.text = "\(seletedRectangle.alpha?.value ?? 0.0)"
+        self.detailView.alphaSlider.value = seletedRectangle.alpha?.value ?? 0.0
         
-        self.detailView.backgroundColorButton.setTitle("\(seletedRectangle.rgb.hexValue)", for: .normal)
+        self.detailView.backgroundColorButton.setTitle("\(seletedRectangle.rgb?.hexValue ?? "")", for: .normal)
     }
 }
 

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -27,7 +27,6 @@ final class MainViewController: UIViewController{
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupRectangleFactory(factory: RectangleFactory.init())
         
         configureNotificationCenter()
         
@@ -39,8 +38,8 @@ final class MainViewController: UIViewController{
     }
     
     //Factory setup
-    private func setupRectangleFactory(factory:RectangleCreator) {
-        self.rectanagleCreator = factory
+    private func setupRectangleFactory(creator:RectangleCreator) {
+        self.rectanagleCreator = creator
     }
     
     
@@ -84,11 +83,12 @@ final class MainViewController: UIViewController{
         rectangleButton.layer.zPosition = 1.0                                //생성되는 사각형에 겹쳐서 안보이는 경우를 막기위해 zPosition을 주었다.
         
         rectangleButton.frame = CGRect(x: x, y: y, width: width, height: height)
-        rectangleButton.addAction(addRectangleAction(), for: .touchUpInside)
+        rectangleButton.addAction(addRectangleAction(rectangleCreator:RectangleFactory.init()), for: .touchUpInside)
     }
     
     //버튼 액션 - 사각형 추가
-    private func addRectangleAction() -> UIAction {
+    private func addRectangleAction(rectangleCreator:RectangleCreator) -> UIAction {
+        setupRectangleFactory(creator:rectangleCreator)
         let action = UIAction {[weak self] _ in
             let rect = self?.rectanagleCreator?.makeRectangle(type: PlaneRectangle.self)
             self?.plane.addRectangle(rectangle: rect as! PlaneRectangle)    //모델에 rectangle을 추가

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -22,9 +22,12 @@ final class MainViewController: UIViewController{
     //선택된 PlaneRectangleView
     private var seletedRectangleView:PlaneRectangleView?
     
+    //factory
+    private var rectanagleCreator:RectangleCreator? = nil
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupRectangleFactory(factory: RectangleFactory.init())
         
         configureNotificationCenter()
         
@@ -34,6 +37,12 @@ final class MainViewController: UIViewController{
         configureTapGesture()
         addViews()
     }
+    
+    //Factory setup
+    private func setupRectangleFactory(factory:RectangleCreator) {
+        self.rectanagleCreator = factory
+    }
+    
     
     //TapGesture
     private func configureTapGesture() {
@@ -75,13 +84,13 @@ final class MainViewController: UIViewController{
         rectangleButton.layer.zPosition = 1.0                                //생성되는 사각형에 겹쳐서 안보이는 경우를 막기위해 zPosition을 주었다.
         
         rectangleButton.frame = CGRect(x: x, y: y, width: width, height: height)
-        rectangleButton.addAction(addRectangleAction(rectangleFactory: RectangleFactory() ), for: .touchUpInside)
+        rectangleButton.addAction(addRectangleAction(), for: .touchUpInside)
     }
     
     //버튼 액션 - 사각형 추가
-    private func addRectangleAction(rectangleFactory:RectangleCreator) -> UIAction {
+    private func addRectangleAction() -> UIAction {
         let action = UIAction {[weak self] _ in
-            let rect = rectangleFactory.makeRectangle(type: PlaneRectangle.self)
+            let rect = self?.rectanagleCreator?.makeRectangle(type: PlaneRectangle.self)
             self?.plane.addRectangle(rectangle: rect as! PlaneRectangle)    //모델에 rectangle을 추가
         }
         return action

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -17,16 +17,15 @@ final class MainViewController: UIViewController{
     private var rectangleButton:UIButton = RectangleButton(frame: .zero)
     private var imageButton:UIButton = ImageButton(frame: .zero)
     
-    //Factory
-    private let rectangleFactory = RectangleFactory()
-    
     //그려진 PlaneRetangleView를 모델(Rectangle)을 Key로 찾는 Dictionary로 만들어서 모델과 매칭을 시켜주었습니다.
     private var retangleViews = [PlaneRectangle:PlaneRectangleView]()
     //선택된 PlaneRectangleView
     private var seletedRectangleView:PlaneRectangleView?
     
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         configureNotificationCenter()
         
         configureImageButton()
@@ -76,13 +75,13 @@ final class MainViewController: UIViewController{
         rectangleButton.layer.zPosition = 1.0                                //생성되는 사각형에 겹쳐서 안보이는 경우를 막기위해 zPosition을 주었다.
         
         rectangleButton.frame = CGRect(x: x, y: y, width: width, height: height)
-        rectangleButton.addAction(addRectangleAction(), for: .touchUpInside)
+        rectangleButton.addAction(addRectangleAction(rectangleFactory: RectangleFactory() ), for: .touchUpInside)
     }
     
     //버튼 액션 - 사각형 추가
-    private func addRectangleAction() -> UIAction {
+    private func addRectangleAction(rectangleFactory:RectangleCreator) -> UIAction {
         let action = UIAction {[weak self] _ in
-            guard let rect = self?.rectangleFactory.makeRectangle(type: PlaneRectangle.self) else { return }
+            let rect = rectangleFactory.makeRectangle(type: PlaneRectangle.self)
             self?.plane.addRectangle(rectangle: rect as! PlaneRectangle)    //모델에 rectangle을 추가
         }
         return action

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -94,7 +94,6 @@ extension MainViewController:UIGestureRecognizerDelegate {
         
         //터치된 View의 origin x와 y값을 plane에게 넘겨줍니다.
         guard let touchedView = touch.view else { return true }
-        if touchedView == self.view { seletedRectangleView?.layer.borderWidth = 0.0 } //빈 화면 클릭시 width을 초기화한다.
         
         //Plane에게 touch된 View의 origin좌표를 넘겨준다.
         let x:Double = touchedView.frame.origin.x

--- a/DrawingApp/DrawingApp/MainViewController.swift
+++ b/DrawingApp/DrawingApp/MainViewController.swift
@@ -16,6 +16,7 @@ final class MainViewController: UIViewController{
     private var detailView = DetailView(frame: .zero)       //생성시 오해를 막고 기존 생성자와 관련있게 하기 위해 frame에 .zero를 대입했습니다.
     private var rectangleButton:UIButton = RectangleButton(frame: .zero)
     private var imageButton:UIButton = ImageButton(frame: .zero)
+    
     //Factory
     private let rectangleFactory = RectangleFactory()
     
@@ -23,9 +24,6 @@ final class MainViewController: UIViewController{
     private var retangleViews = [PlaneRectangle:PlaneRectangleView]()
     //선택된 PlaneRectangleView
     private var seletedRectangleView:PlaneRectangleView?
-    
-    private let imagePicker = UIImagePickerController()
-
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -66,17 +64,7 @@ final class MainViewController: UIViewController{
         
         imageButton.layer.zPosition = 1.0
         imageButton.frame = CGRect(x: x, y: y, width: width, height: height)
-        imageButton.addAction(addImageRectangleAction(), for: .touchUpInside)
     }
-    
-    private func addImageRectangleAction() -> UIAction {
-        let action = UIAction {[weak self] _ in
-            guard let rect = self?.rectangleFactory.makePlaneRectangle() else { return }
-            self?.plane.addRectangle(rectangle: rect)    //모델에 rectangle을 추가
-        }
-        return action
-    }
-    
     
     //사각형 추가 버튼 Frame정의 및 Action추가.
     private func configureRectangleButton() {
@@ -94,8 +82,8 @@ final class MainViewController: UIViewController{
     //버튼 액션 - 사각형 추가
     private func addRectangleAction() -> UIAction {
         let action = UIAction {[weak self] _ in
-            guard let rect = self?.rectangleFactory.makePlaneRectangle() else { return }
-            self?.plane.addRectangle(rectangle: rect)    //모델에 rectangle을 추가
+            guard let rect = self?.rectangleFactory.makeRectangle(type: PlaneRectangle.self) else { return }
+            self?.plane.addRectangle(rectangle: rect as! PlaneRectangle)    //모델에 rectangle을 추가
         }
         return action
     }

--- a/DrawingApp/DrawingApp/Model/Image.swift
+++ b/DrawingApp/DrawingApp/Model/Image.swift
@@ -1,0 +1,24 @@
+//
+//  Image.swift
+//  DrawingApp
+//
+//  Created by 박진섭 on 2022/03/14.
+//
+
+import Foundation
+
+class Image {
+    
+    private var rectangles:[Point:ImageRectangle] = [:]
+    private var selectedRectangle:ImageRectangle?
+    
+    var count:Int {
+        self.rectangles.count
+    }
+    
+    
+    
+    
+    
+    
+}

--- a/DrawingApp/DrawingApp/Model/Image.swift
+++ b/DrawingApp/DrawingApp/Model/Image.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+//TODO: Something deal with ImageRectangle
 class Image {
     
     private var rectangles:[Point:ImageRectangle] = [:]
@@ -15,10 +16,4 @@ class Image {
     var count:Int {
         self.rectangles.count
     }
-    
-    
-    
-    
-    
-    
 }

--- a/DrawingApp/DrawingApp/Model/ImageRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/ImageRectangle.swift
@@ -8,15 +8,15 @@
 import UIKit
 
 //Rectangle의 구조를 따르지만, Image프로퍼티가 추가되어있는 Class가 ImageRectangle이라 생각하여 선언.
-final class ImageRectangle:Rectangle {
+final class ImageRectangle:Rectangleable {
 
     private let id:ID
     private(set) var origin:Point
     private(set) var size:Size
-    private(set) var alpha:Alpha
+    private(set) var alpha:Alpha?
     private(set) var image:Data?
     
-    init(id: ID, origin: Point, size: Size, rgb: RGB, alpha: Alpha) {
+    init(id: ID, origin: Point, size: Size, rgb: RGB?, alpha: Alpha?) {
         self.id = id
         self.origin = origin
         self.size = size

--- a/DrawingApp/DrawingApp/Model/ImageRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/ImageRectangle.swift
@@ -7,28 +7,34 @@
 
 import UIKit
 
-//Rectangle의 구조를 따르지만, Image프로퍼티가 추가되어있는 Class가 ImageRectangle이라 생각하여 선언했습니다.
-final class ImageRectangle:CustomStringConvertible,Rectangle {
+//Rectangle의 구조를 따르지만, Image프로퍼티가 추가되어있는 Class가 ImageRectangle이라 생각하여 선언.
+final class ImageRectangle:Rectangle {
 
-    var description: String {
-        return "\(id), \(origin), \(size), \(alpha)"
-    }
-    
     var id:ID
     var origin:Point
     var size:Size
     var alpha:Alpha
-    var rgb: RGB
-    var image:UIImage?
+    var image:Data?
         
-    init(id: ID, origin: Point, size: Size,rgb: RGB,alpha:Alpha) {
+    init(id: ID, origin: Point, size: Size ,alpha:Alpha) {
         self.id = id
         self.origin = origin
         self.size = size
-        self.rgb = rgb
         self.alpha = alpha
     }
 
+    func changeOrigin(_ origin: Point) {
+        self.origin = origin
+    }
+    
+    func changeSize(_ size: Size) {
+        self.size = size
+    }
+    
+    func changeAlpha(_ alpha: Alpha) {
+        self.alpha = alpha
+    }
+    
 }
 
 //선택한 Rectangle모델을 찾기위해 Dictionary를 선언했기에 Hashable프로토콜을 채택한다.
@@ -36,7 +42,8 @@ extension ImageRectangle:Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(self.id)
     }
+    //이미지가 같은면 같은 사각형.
     static func == (lhs: ImageRectangle, rhs: ImageRectangle) -> Bool {
-        lhs.id == rhs.id
+        lhs.image == rhs.image
     }
 }

--- a/DrawingApp/DrawingApp/Model/ImageRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/ImageRectangle.swift
@@ -5,7 +5,7 @@
 //  Created by 박진섭 on 2022/03/14.
 //
 
-import UIKit
+import Foundation
 
 //Rectangle의 구조를 따르지만, Image프로퍼티가 추가되어있는 Class가 ImageRectangle이라 생각하여 선언.
 final class ImageRectangle:Rectangleable {
@@ -14,13 +14,15 @@ final class ImageRectangle:Rectangleable {
     private(set) var origin:Point
     private(set) var size:Size
     private(set) var alpha:Alpha?
+    private(set) var rgb:RGB?
     private(set) var image:Data?
     
-    init(id: ID, origin: Point, size: Size, rgb: RGB?, alpha: Alpha?) {
+    init(id: ID, origin: Point, size: Size, rgb: RGB? = nil, alpha: Alpha? = nil) {
         self.id = id
         self.origin = origin
         self.size = size
         self.alpha = alpha
+        self.rgb = rgb
     }
 
     func changeOrigin(_ origin: Point) {

--- a/DrawingApp/DrawingApp/Model/ImageRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/ImageRectangle.swift
@@ -10,11 +10,11 @@ import UIKit
 //Rectangle의 구조를 따르지만, Image프로퍼티가 추가되어있는 Class가 ImageRectangle이라 생각하여 선언.
 final class ImageRectangle:Rectangle {
 
-    var id:ID
-    var origin:Point
-    var size:Size
-    var alpha:Alpha
-    var image:Data?
+    private let id:ID
+    private(set) var origin:Point
+    private(set) var size:Size
+    private(set) var alpha:Alpha
+    private(set) var image:Data?
         
     init(id: ID, origin: Point, size: Size ,alpha:Alpha) {
         self.id = id

--- a/DrawingApp/DrawingApp/Model/ImageRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/ImageRectangle.swift
@@ -5,9 +5,11 @@
 //  Created by 박진섭 on 2022/03/14.
 //
 
+import UIKit
 
+//Rectangle의 구조를 따르지만, Image프로퍼티가 추가되어있는 Class가 ImageRectangle이라 생각하여 선언했습니다.
 final class ImageRectangle:CustomStringConvertible,Rectangle {
-    
+
     var description: String {
         return "\(id), \(origin), \(size), \(alpha)"
     }
@@ -16,14 +18,17 @@ final class ImageRectangle:CustomStringConvertible,Rectangle {
     var origin:Point
     var size:Size
     var alpha:Alpha
-    
-    init(id:ID,origin:Point,size:Size, alpha:Alpha) {
+    var rgb: RGB
+    var image:UIImage?
+        
+    init(id: ID, origin: Point, size: Size,rgb: RGB,alpha:Alpha) {
         self.id = id
         self.origin = origin
         self.size = size
+        self.rgb = rgb
         self.alpha = alpha
     }
-    
+
 }
 
 //선택한 Rectangle모델을 찾기위해 Dictionary를 선언했기에 Hashable프로토콜을 채택한다.

--- a/DrawingApp/DrawingApp/Model/ImageRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/ImageRectangle.swift
@@ -15,8 +15,8 @@ final class ImageRectangle:Rectangle {
     private(set) var size:Size
     private(set) var alpha:Alpha
     private(set) var image:Data?
-        
-    init(id: ID, origin: Point, size: Size ,alpha:Alpha) {
+    
+    init(id: ID, origin: Point, size: Size, rgb: RGB, alpha: Alpha) {
         self.id = id
         self.origin = origin
         self.size = size

--- a/DrawingApp/DrawingApp/Model/ImageRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/ImageRectangle.swift
@@ -1,0 +1,37 @@
+//
+//  ImageRectangle.swift
+//  DrawingApp
+//
+//  Created by 박진섭 on 2022/03/14.
+//
+
+
+final class ImageRectangle:CustomStringConvertible,Rectangle {
+    
+    var description: String {
+        return "\(id), \(origin), \(size), \(alpha)"
+    }
+    
+    var id:ID
+    var origin:Point
+    var size:Size
+    var alpha:Alpha
+    
+    init(id:ID,origin:Point,size:Size, alpha:Alpha) {
+        self.id = id
+        self.origin = origin
+        self.size = size
+        self.alpha = alpha
+    }
+    
+}
+
+//선택한 Rectangle모델을 찾기위해 Dictionary를 선언했기에 Hashable프로토콜을 채택한다.
+extension ImageRectangle:Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.id)
+    }
+    static func == (lhs: ImageRectangle, rhs: ImageRectangle) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -9,9 +9,6 @@ import Foundation
 
 public class Plane {
     
-    //NotificationCenter.default가 중복되는것 같아 private 상수로 선언했습니다.
-    private let defultNotificationCenter = NotificationCenter.default
-    
     //Point를 기반으로 Dictionary를 만듬으로써 View에서 TapGesture로 좌표값을 넘겼을때 그에 해당하는 Rectangle을 찾을 수있다.
     var rectangles:[Point:Rectangle] = [:]
     var selectedRectangle:Rectangle?
@@ -25,7 +22,7 @@ public class Plane {
         guard let selectedRectangle = selectedRectangle else { return }
         selectedRectangle.alpha = alpha
         
-        defultNotificationCenter.post(
+        NotificationCenter.default.post(
             name: Plane.NotificationName.didchangeRectangleAlpha,
             object: self,
             userInfo: [Plane.UserInfoKey.changedAlpha:alpha]
@@ -37,7 +34,7 @@ public class Plane {
         guard let selectedRectangle = selectedRectangle else { return }
         selectedRectangle.rgb = color
         
-        defultNotificationCenter.post(
+        NotificationCenter.default.post(
             name: Plane.NotificationName.didChangeRectangleColor,
             object: self,
             userInfo: [Plane.UserInfoKey.changedColor:color]
@@ -51,7 +48,7 @@ public class Plane {
         let key = Point(x: x, y: y)
         
         rectangles[key] = rectangle
-        defultNotificationCenter.post(
+        NotificationCenter.default.post(
                 name: Plane.NotificationName.didAddRectangle,
                 object: self,
                 userInfo:[Plane.UserInfoKey.addedRectangle: rectangle]
@@ -68,7 +65,7 @@ public class Plane {
         guard let foundRectangle = rectangles[key] else { return }
         self.selectedRectangle = foundRectangle
         
-        defultNotificationCenter.post(
+        NotificationCenter.default.post(
             name: Plane.NotificationName.didFindRectangle,
             object: self,
             userInfo: [Plane.UserInfoKey.foundRectangle:foundRectangle]     

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -56,31 +56,47 @@ public class Plane {
     }
     
     //특정 좌표에 맞는 retangle을 찾고 seletedRectangle에 대입합니다.
-    func findSeletedRectangle(x:Double,y:Double) {
+    func findSeletedRectangle(x:Double,y:Double,size:Size) {
+        
+        checkEmptySpace(size: size)
+        
         let convertX = round(x)
         let convertY = round(y)
         
         let key = Point(x: convertX, y: convertY)
         
-        //ViewController에서 하던 빈 화면 클릭시 처리하는 로직을 입출력 구분을 위해, guard let으로 바로 리턴하지 않고 if let으로 바인딩 하면서 조건을 주었습니다.
-        if let foundRectangle = rectangles[key] {
-            self.selectedRectangle = foundRectangle
-            
-            NotificationCenter.default.post(
-                name: Plane.NotificationName.didFindRectangle,
-                object: self,
-                userInfo: [Plane.UserInfoKey.foundRectangle:foundRectangle]
-            )
-        } else {
+        guard let foundRectangle = rectangles[key] else { return  }
+        self.selectedRectangle = foundRectangle
+        
+        NotificationCenter.default.post(
+            name: Plane.NotificationName.didFindRectangle,
+            object: self,
+            userInfo: [Plane.UserInfoKey.foundRectangle:foundRectangle as Any]
+        )
+    }
+    
+    //빈화면을 클릭할 시 아무런 정보를 가지지 않은 채로 post합니다.
+    //nil값을 가진채로 Dictionary를 만들어 Userinfo를 보내도 같은 결과가 나오지만 굳이 Dictionary를 만들어 보낼 필요를 못느껴 새로운 post를 만들었습니다.
+    private func checkEmptySpace(size:Size) {
+        if isEmptySpace(size: size) {
             self.selectedRectangle = nil
-            
             NotificationCenter.default.post(
                 name: Plane.NotificationName.didFindRectangle,
-                object: self,
-                userInfo: [Plane.UserInfoKey.foundRectangle:selectedRectangle as Any]
+                object: self
             )
         }
     }
+    
+    //Size값이 최대값을 가지고 있다면 빈 화면을 클릭한 것입니다.
+    private func isEmptySpace(size:Size) -> Bool{
+        let height = size.height
+        let width = size.width
+        let emptySpaceSize = Size(width: Size.maxWidth, height: Size.maxHeight)
+        
+        return emptySpaceSize == Size(width: width, height: height) ? true : false
+    }
+    
+    
     
     //Plane.UserInfoKey와 같이 Plane과 관련있게 하고싶어서 Nested Enum을 선언했습니다.
     enum UserInfoKey {

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -62,14 +62,25 @@ public class Plane {
         
         let key = Point(x: convertX, y: convertY)
         
-        guard let foundRectangle = rectangles[key] else { return }
-        self.selectedRectangle = foundRectangle
-        
-        NotificationCenter.default.post(
-            name: Plane.NotificationName.didFindRectangle,
-            object: self,
-            userInfo: [Plane.UserInfoKey.foundRectangle:foundRectangle]     
-        )
+        //ViewController에서 하던 빈 화면 클릭시 처리하는 로직을 입출력 구분을 위해, guard let으로 바로 리턴하지 않고 if let으로 바인딩 하면서 조건을 주었습니다.
+        if let foundRectangle = rectangles[key] {
+            self.selectedRectangle = foundRectangle
+            
+            NotificationCenter.default.post(
+                name: Plane.NotificationName.didFindRectangle,
+                object: self,
+                userInfo: [Plane.UserInfoKey.foundRectangle:foundRectangle]
+            )
+            
+        } else {
+            self.selectedRectangle = nil
+            NotificationCenter.default.post(
+                name: Plane.NotificationName.didFindRectangle,
+                object: self,
+                userInfo: [Plane.UserInfoKey.foundRectangle:selectedRectangle as Any]
+            )
+        }
+
     }
     
     //Plane.UserInfoKey와 같이 Plane과 관련있게 하고싶어서 Nested Enum을 선언했습니다.

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -10,8 +10,8 @@ import Foundation
 public class Plane {
     
     //Point를 기반으로 Dictionary를 만듬으로써 View에서 TapGesture로 좌표값을 넘겼을때 그에 해당하는 Rectangle을 찾을 수있다.
-    private var rectangles:[Point:Rectangle] = [:]
-    private var selectedRectangle:Rectangle?
+    private var rectangles:[Point:PlaneRectangle] = [:]
+    private var selectedRectangle:PlaneRectangle?
     
     var count:Int {
         self.rectangles.count
@@ -41,7 +41,7 @@ public class Plane {
         )
     }
     
-    func addRectangle(rectangle:Rectangle) {
+    func addRectangle(rectangle:PlaneRectangle) {
         //Double로 만들어지는 Point값이 소수점에서 미세한 차이가 생길 수 있어서 round로 한번 변환을 시켰습니다.
         let x = round(rectangle.origin.x)
         let y = round(rectangle.origin.y)

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -41,18 +41,22 @@ public class Plane {
         )
     }
     
-    func addRectangle(rectangle:PlaneRectangle) {
-        //Double로 만들어지는 Point값이 소수점에서 미세한 차이가 생길 수 있어서 round로 한번 변환을 시켰습니다.
-        let x = round(rectangle.origin.x)
-        let y = round(rectangle.origin.y)
+    //사각형 생성,추가.
+    @discardableResult
+    func addRectangle(creator:RectangleCreator) -> PlaneRectangle{
+        let rect = creator.makeRectangle(type: PlaneRectangle.self) as! PlaneRectangle
+        //Double로 만들어지는 Point값이 소수점에서 미세한 차이가 생길 수 있어서 round로 한번 변환
+        let x = round(rect.origin.x)
+        let y = round(rect.origin.y)
         let key = Point(x: x, y: y)
         
-        rectangles[key] = rectangle
+        rectangles[key] = rect
         NotificationCenter.default.post(
                 name: Plane.NotificationName.didAddRectangle,
                 object: self,
-                userInfo:[Plane.UserInfoKey.addedRectangle: rectangle]
+                userInfo:[Plane.UserInfoKey.addedRectangle: rect]
         )
+        return rect
     }
     
     //특정 좌표에 맞는 retangle을 찾고 seletedRectangle에 대입합니다.
@@ -65,7 +69,7 @@ public class Plane {
         
         let key = Point(x: convertX, y: convertY)
         
-        guard let foundRectangle = rectangles[key] else { return  }
+        guard let foundRectangle = rectangles[key] else { return }
         self.selectedRectangle = foundRectangle
         
         NotificationCenter.default.post(

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -10,8 +10,8 @@ import Foundation
 public class Plane {
     
     //Point를 기반으로 Dictionary를 만듬으로써 View에서 TapGesture로 좌표값을 넘겼을때 그에 해당하는 Rectangle을 찾을 수있다.
-    var rectangles:[Point:Rectangle] = [:]
-    var selectedRectangle:Rectangle?
+    private var rectangles:[Point:Rectangle] = [:]
+    private var selectedRectangle:Rectangle?
     
     var count:Int {
         self.rectangles.count
@@ -71,16 +71,15 @@ public class Plane {
                 object: self,
                 userInfo: [Plane.UserInfoKey.foundRectangle:foundRectangle]
             )
-            
         } else {
             self.selectedRectangle = nil
+            
             NotificationCenter.default.post(
                 name: Plane.NotificationName.didFindRectangle,
                 object: self,
                 userInfo: [Plane.UserInfoKey.foundRectangle:selectedRectangle as Any]
             )
         }
-
     }
     
     //Plane.UserInfoKey와 같이 Plane과 관련있게 하고싶어서 Nested Enum을 선언했습니다.
@@ -93,7 +92,7 @@ public class Plane {
     
     //enum과 Struct사이에서 고민을 했으나 static let으로 선언하고 case로 선언을 하지 않을 것이라면 Struct가 더 알맞다고 생각했습니다.
     struct NotificationName {
-        static let didchangeRectangleAlpha = Notification.Name("didchangeRectangleAlpha")
+        static let didchangeRectangleAlpha = Notification.Name("didChangeRectangleAlpha")
         static let didChangeRectangleColor = Notification.Name("didChangeRectangleColor")
         static let didAddRectangle = Notification.Name("didAddRectangle")
         static let didFindRectangle = Notification.Name("didFindRectangle")

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -20,7 +20,7 @@ public class Plane {
     
     func change(alpha:Alpha){
         guard let selectedRectangle = selectedRectangle else { return }
-        selectedRectangle.alpha = alpha
+        selectedRectangle.changeAlpha(alpha)
         
         NotificationCenter.default.post(
             name: Plane.NotificationName.didchangeRectangleAlpha,
@@ -32,7 +32,7 @@ public class Plane {
     
     func change(color:RGB) {
         guard let selectedRectangle = selectedRectangle else { return }
-        selectedRectangle.rgb = color
+        selectedRectangle.changeColor(color)
         
         NotificationCenter.default.post(
             name: Plane.NotificationName.didChangeRectangleColor,
@@ -71,7 +71,7 @@ public class Plane {
         NotificationCenter.default.post(
             name: Plane.NotificationName.didFindRectangle,
             object: self,
-            userInfo: [Plane.UserInfoKey.foundRectangle:foundRectangle as Any]
+            userInfo: [Plane.UserInfoKey.foundRectangle:foundRectangle]
         )
     }
     
@@ -98,7 +98,7 @@ public class Plane {
     
     
     
-    //Plane.UserInfoKey와 같이 Plane과 관련있게 하고싶어서 Nested Enum을 선언했습니다.
+    //Plane.UserInfoKey와 같이 Plane과 관련있게 하고싶어서 Nested Enum을 선언
     enum UserInfoKey {
         case addedRectangle
         case foundRectangle
@@ -106,7 +106,7 @@ public class Plane {
         case changedAlpha
     }
     
-    //enum과 Struct사이에서 고민을 했으나 static let으로 선언하고 case로 선언을 하지 않을 것이라면 Struct가 더 알맞다고 생각했습니다.
+   //NotificationNames
     struct NotificationName {
         static let didchangeRectangleAlpha = Notification.Name("didChangeRectangleAlpha")
         static let didChangeRectangleColor = Notification.Name("didChangeRectangleColor")

--- a/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
@@ -18,11 +18,11 @@ final class PlaneRectangle:CustomStringConvertible,Rectangle {
     var rgb:RGB
     var alpha:Alpha
     
-    init(id:ID,origin:Point,size:Size,backGroundColor:RGB, alpha:Alpha) {
+    init(id:ID,origin:Point,size:Size,rgb:RGB, alpha:Alpha) {
         self.id = id
         self.origin = origin
         self.size = size
-        self.rgb = backGroundColor
+        self.rgb = rgb
         self.alpha = alpha
     }
     

--- a/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
@@ -8,11 +8,11 @@
 
 final class PlaneRectangle:Rectangle {
         
-    private var id:ID
-    private var origin:Point
-    private var size:Size
-    private var rgb:RGB
-    private var alpha:Alpha
+    private let id:ID
+    private(set) var origin:Point
+    private(set) var size:Size
+    private(set) var rgb:RGB
+    private(set) var alpha:Alpha
     
     init(id:ID,origin:Point,size:Size,rgb:RGB, alpha:Alpha) {
         self.id = id
@@ -33,6 +33,11 @@ final class PlaneRectangle:Rectangle {
     func changeAlpha(_ alpha: Alpha) {
         self.alpha = alpha
     }
+    
+    func changeColor(_ rgb:RGB) {
+        self.rgb = rgb
+    }
+    
     
 }
 

--- a/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
@@ -6,7 +6,7 @@
 //
 
 
-final class PlaneRectangle:Rectangle {
+final class PlaneRectangle:Rectangleable {
         
     private let id:ID
     private(set) var origin:Point
@@ -14,12 +14,12 @@ final class PlaneRectangle:Rectangle {
     private(set) var rgb:RGB
     private(set) var alpha:Alpha
     
-    init(id:ID,origin:Point,size:Size,rgb:RGB, alpha:Alpha) {
+    init(id:ID,origin:Point,size:Size,rgb:RGB?, alpha:Alpha?) {
         self.id = id
         self.origin = origin
         self.size = size
-        self.rgb = rgb
-        self.alpha = alpha
+        self.rgb = rgb ?? RGB(red: 0, green: 0, blue: 0)
+        self.alpha = alpha ?? Alpha(1.0)
     }
     
     func changeOrigin(_ origin: Point) {

--- a/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
@@ -11,15 +11,15 @@ final class PlaneRectangle:Rectangleable {
     private let id:ID
     private(set) var origin:Point
     private(set) var size:Size
-    private(set) var rgb:RGB
-    private(set) var alpha:Alpha
+    private(set) var rgb:RGB?
+    private(set) var alpha:Alpha?
     
-    init(id:ID,origin:Point,size:Size,rgb:RGB?, alpha:Alpha?) {
+    init(id:ID,origin:Point,size:Size,rgb:RGB? = nil , alpha:Alpha? = nil) {
         self.id = id
         self.origin = origin
         self.size = size
-        self.rgb = rgb ?? RGB(red: 0, green: 0, blue: 0)
-        self.alpha = alpha ?? Alpha(1.0)
+        self.rgb = rgb
+        self.alpha = alpha
     }
     
     func changeOrigin(_ origin: Point) {

--- a/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
@@ -6,23 +6,31 @@
 //
 
 
-final class PlaneRectangle:CustomStringConvertible,Rectangle {
-    
-    var description: String {
-        return "\(id), \(origin), \(size),\(rgb), \(alpha)"
-    }
-    
-    var id:ID
-    var origin:Point
-    var size:Size
-    var rgb:RGB
-    var alpha:Alpha
+final class PlaneRectangle:Rectangle {
+        
+    private var id:ID
+    private var origin:Point
+    private var size:Size
+    private var rgb:RGB
+    private var alpha:Alpha
     
     init(id:ID,origin:Point,size:Size,rgb:RGB, alpha:Alpha) {
         self.id = id
         self.origin = origin
         self.size = size
         self.rgb = rgb
+        self.alpha = alpha
+    }
+    
+    func changeOrigin(_ origin: Point) {
+        self.origin = origin
+    }
+    
+    func changeSize(_ size: Size) {
+        self.size = size
+    }
+    
+    func changeAlpha(_ alpha: Alpha) {
         self.alpha = alpha
     }
     
@@ -33,7 +41,8 @@ extension PlaneRectangle:Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(self.id)
     }
+    //기본 사각형 속성 비교.
     static func == (lhs: PlaneRectangle, rhs: PlaneRectangle) -> Bool {
-        lhs.id == rhs.id
+        lhs.rgb == rhs.rgb && lhs.alpha == rhs.alpha && lhs.size == rhs.size
     }
 }

--- a/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
+++ b/DrawingApp/DrawingApp/Model/PlaneRectangle.swift
@@ -1,19 +1,20 @@
 //
-//  Rectangle.swift
+//  PlaneRectangle.swift
 //  DrawingApp
 //
-//  Created by 박진섭 on 2022/03/01.
+//  Created by 박진섭 on 2022/03/14.
 //
 
-final class Rectangle:CustomStringConvertible {
+
+final class PlaneRectangle:CustomStringConvertible,Rectangle {
     
     var description: String {
         return "\(id), \(origin), \(size),\(rgb), \(alpha)"
     }
     
-    private let id:ID
-    let origin:Point
-    let size:Size
+    var id:ID
+    var origin:Point
+    var size:Size
     var rgb:RGB
     var alpha:Alpha
     
@@ -28,12 +29,11 @@ final class Rectangle:CustomStringConvertible {
 }
 
 //선택한 Rectangle모델을 찾기위해 Dictionary를 선언했기에 Hashable프로토콜을 채택한다.
-extension Rectangle:Hashable {
+extension PlaneRectangle:Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(self.id)
     }
-    static func == (lhs: Rectangle, rhs: Rectangle) -> Bool {
+    static func == (lhs: PlaneRectangle, rhs: PlaneRectangle) -> Bool {
         lhs.id == rhs.id
     }
 }
-

--- a/DrawingApp/DrawingApp/Protocol/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Protocol/Rectangle.swift
@@ -7,6 +7,7 @@
 
 //사각형의 기본 메서드 프로토콜.
 protocol Rectangle {
+    init(id:ID,origin:Point,size:Size,rgb:RGB, alpha:Alpha)
     func changeOrigin(_ origin:Point)
     func changeSize(_ size:Size)
     func changeAlpha(_ alpha:Alpha)

--- a/DrawingApp/DrawingApp/Protocol/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Protocol/Rectangle.swift
@@ -1,0 +1,13 @@
+//
+//  Rectangle0.swift
+//  DrawingApp
+//
+//  Created by 박진섭 on 2022/03/14.
+//
+
+protocol Rectangle {
+    var id:ID { get set}
+    var origin:Point { get set}
+    var size:Size { get set}
+    var alpha:Alpha { get set}
+}

--- a/DrawingApp/DrawingApp/Protocol/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Protocol/Rectangle.swift
@@ -5,9 +5,11 @@
 //  Created by 박진섭 on 2022/03/14.
 //
 
+//사각형의 기본이 되려면 밑과같은 프로퍼티가 기본적으로 있어야 할것 같아 protocol로 선언했습니다.
 protocol Rectangle {
     var id:ID { get set}
     var origin:Point { get set}
     var size:Size { get set}
     var alpha:Alpha { get set}
+    var rgb:RGB { get set }
 }

--- a/DrawingApp/DrawingApp/Protocol/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Protocol/Rectangle.swift
@@ -5,11 +5,9 @@
 //  Created by 박진섭 on 2022/03/14.
 //
 
-//사각형의 기본이 되려면 밑과같은 프로퍼티가 기본적으로 있어야 할것 같아 protocol로 선언했습니다.
+//사각형의 기본 메서드 프로토콜.
 protocol Rectangle {
-    var id:ID { get set}
-    var origin:Point { get set}
-    var size:Size { get set}
-    var alpha:Alpha { get set}
-    var rgb:RGB { get set }
+    func changeOrigin(_ origin:Point)
+    func changeSize(_ size:Size)
+    func changeAlpha(_ alpha:Alpha)
 }

--- a/DrawingApp/DrawingApp/Protocol/RectangleCreator.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleCreator.swift
@@ -1,0 +1,11 @@
+//
+//  RectangleCreator.swift
+//  DrawingApp
+//
+//  Created by 박진섭 on 2022/03/14.
+//
+
+protocol RectangleCreator {
+    func makePlaneRectangle() -> PlaneRectangle
+    func makeImageRectangle() -> ImageRectangle
+}

--- a/DrawingApp/DrawingApp/Protocol/RectangleCreator.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleCreator.swift
@@ -6,5 +6,5 @@
 //
 
 protocol RectangleCreator {
-    func makeRectangle(type:Rectangle.Type) -> Rectangle
+    func makeRectangle(type:Rectangle.Type) -> Rectangle 
 }

--- a/DrawingApp/DrawingApp/Protocol/RectangleCreator.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleCreator.swift
@@ -6,5 +6,5 @@
 //
 
 protocol RectangleCreator {
-    func makeRectangle(type:Rectangle.Type) -> Rectangle 
+    func makeRectangle(type:Rectangleable.Type) -> Rectangleable 
 }

--- a/DrawingApp/DrawingApp/Protocol/RectangleCreator.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleCreator.swift
@@ -6,6 +6,5 @@
 //
 
 protocol RectangleCreator {
-    func makePlaneRectangle() -> PlaneRectangle
-    func makeImageRectangle() -> ImageRectangle
+    func makeRectangle(type:ObjectIdentifier) -> Rectangle
 }

--- a/DrawingApp/DrawingApp/Protocol/RectangleCreator.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleCreator.swift
@@ -6,5 +6,5 @@
 //
 
 protocol RectangleCreator {
-    func makeRectangle(type:ObjectIdentifier) -> Rectangle
+    func makeRectangle(type:Rectangle.Type) -> Rectangle
 }

--- a/DrawingApp/DrawingApp/Protocol/RectangleView.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleView.swift
@@ -1,0 +1,8 @@
+//
+//  RectangleView.swift
+//  DrawingApp
+//
+//  Created by 박진섭 on 2022/03/15.
+//
+
+import Foundation

--- a/DrawingApp/DrawingApp/Protocol/RectangleView.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleView.swift
@@ -1,0 +1,11 @@
+//
+//  RectangleViewAble.swift
+//  DrawingApp
+//
+//  Created by 박진섭 on 2022/03/16.
+//
+
+protocol RectangleViewAble {
+    func setupFrameWithPlaneRectangle(rect:Rectangle)
+    func 
+}

--- a/DrawingApp/DrawingApp/Protocol/RectangleView.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleView.swift
@@ -1,8 +1,0 @@
-//
-//  RectangleView.swift
-//  DrawingApp
-//
-//  Created by 박진섭 on 2022/03/15.
-//
-
-import Foundation

--- a/DrawingApp/DrawingApp/Protocol/RectangleViewCreator.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleViewCreator.swift
@@ -5,4 +5,6 @@
 //  Created by 박진섭 on 2022/03/15.
 //
 
-import Foundation
+protocol RectangleViewCreator {
+    func makeRectangleView(type:RectangleViewable.Type) -> RectangleViewable
+}

--- a/DrawingApp/DrawingApp/Protocol/RectangleViewCreator.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleViewCreator.swift
@@ -1,0 +1,8 @@
+//
+//  RectangleViewCreator.swift
+//  DrawingApp
+//
+//  Created by 박진섭 on 2022/03/15.
+//
+
+import Foundation

--- a/DrawingApp/DrawingApp/Protocol/RectangleViewCreator.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleViewCreator.swift
@@ -6,5 +6,5 @@
 //
 
 protocol RectangleViewCreator {
-    func makeRectangleView(type:RectangleViewable.Type) -> RectangleViewable
+    static func makeRectangleView(sourceRectangle:Rectangleable) -> RectangleViewable
 }

--- a/DrawingApp/DrawingApp/Protocol/RectangleViewable.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleViewable.swift
@@ -1,11 +1,10 @@
 //
-//  RectangleView.swift
+//  RectangleViewable.swift
 //  DrawingApp
 //
 //  Created by 박진섭 on 2022/03/16.
 //
 
-protocol RectangleViewAble {
-    func setupFrameWithPlaneRectangle()
-    func 
+protocol RectangleViewable {
+    func setupFrameWithRectangle(rect:Rectangleable)
 }

--- a/DrawingApp/DrawingApp/Protocol/RectangleViewable.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleViewable.swift
@@ -5,6 +5,8 @@
 //  Created by 박진섭 on 2022/03/16.
 //
 
-protocol RectangleViewable {
+import UIKit
+
+protocol RectangleViewable:UIView {
     func setupFrameWithRectangle(rect:Rectangleable)
 }

--- a/DrawingApp/DrawingApp/Protocol/RectangleViewable.swift
+++ b/DrawingApp/DrawingApp/Protocol/RectangleViewable.swift
@@ -1,0 +1,11 @@
+//
+//  RectangleView.swift
+//  DrawingApp
+//
+//  Created by 박진섭 on 2022/03/16.
+//
+
+protocol RectangleViewAble {
+    func setupFrameWithPlaneRectangle()
+    func 
+}

--- a/DrawingApp/DrawingApp/Protocol/Rectangleable.swift
+++ b/DrawingApp/DrawingApp/Protocol/Rectangleable.swift
@@ -6,7 +6,7 @@
 //
 
 //사각형의 기본 메서드 프로토콜.
-protocol Retangleable {
+protocol Rectangleable {
     init(id:ID,origin:Point,size:Size,rgb:RGB?, alpha:Alpha?)
     func changeOrigin(_ origin:Point)
     func changeSize(_ size:Size)

--- a/DrawingApp/DrawingApp/Protocol/Retangleable.swift
+++ b/DrawingApp/DrawingApp/Protocol/Retangleable.swift
@@ -1,13 +1,13 @@
 //
-//  Rectangle0.swift
+//  Retangleable.swift
 //  DrawingApp
 //
 //  Created by 박진섭 on 2022/03/14.
 //
 
 //사각형의 기본 메서드 프로토콜.
-protocol Rectangle {
-    init(id:ID,origin:Point,size:Size,rgb:RGB, alpha:Alpha)
+protocol Retangleable {
+    init(id:ID,origin:Point,size:Size,rgb:RGB?, alpha:Alpha?)
     func changeOrigin(_ origin:Point)
     func changeSize(_ size:Size)
     func changeAlpha(_ alpha:Alpha)

--- a/DrawingApp/DrawingApp/ShapeElement/Point.swift
+++ b/DrawingApp/DrawingApp/ShapeElement/Point.swift
@@ -5,7 +5,7 @@
 //  Created by 박진섭 on 2022/03/01.
 //
 
-struct Point:CustomStringConvertible {
+struct Point:CustomStringConvertible,Hashable {
     
     var description: String {
         "X:\(x), Y:\(y)"
@@ -29,9 +29,5 @@ struct Point:CustomStringConvertible {
         self.x = x
         self.y = y
     }
-    
-}
-
-extension Point:Hashable {
     
 }

--- a/DrawingApp/DrawingApp/ShapeElement/Size.swift
+++ b/DrawingApp/DrawingApp/ShapeElement/Size.swift
@@ -5,7 +5,7 @@
 //  Created by 박진섭 on 2022/03/01.
 //
 
-struct Size:CustomStringConvertible{
+struct Size:CustomStringConvertible,Equatable{
     
     var description: String {
         "W\(width), H\(height)"
@@ -33,6 +33,3 @@ struct Size:CustomStringConvertible{
     
 }
 
-extension Size:Equatable {
-    
-}

--- a/DrawingApp/DrawingApp/ShapeElement/Size.swift
+++ b/DrawingApp/DrawingApp/ShapeElement/Size.swift
@@ -32,3 +32,7 @@ struct Size:CustomStringConvertible{
     }
     
 }
+
+extension Size:Equatable {
+    
+}

--- a/DrawingApp/DrawingApp/View/ImageButton.swift
+++ b/DrawingApp/DrawingApp/View/ImageButton.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-//button을 정의하는 코드가 너무 길어져서 ViewController에서 Button을 분리해서 선언했습니다.
+//ImageButton
 final class ImageButton:UIButton {
     
     override init(frame: CGRect) {
@@ -25,7 +25,7 @@ final class ImageButton:UIButton {
     }
     
     
-    //사각형 추가 버튼
+    //이미지 사각형 추가 버튼
     private func configureImageButton() {
         self.tintColor = .black
         
@@ -44,12 +44,12 @@ final class ImageButton:UIButton {
     }
     
     
-    //버튼 액션 - highLigted
+    //이미지 추가 사각형 버튼 액션 - highLigted
     private func configureImageButtonTapped() {
         let squareImage = UIImage(systemName: "photo")
         let highlightedImage = UIImage(systemName: "photo.fill")
         
-        //사각형 버튼 터치시 변화를 보여주기 위해 선언함.
+        //버튼 터치시 변화를 보여주기 위해 선언함.
         self.configurationUpdateHandler = { button in
             var configuration = button.configuration
             configuration?.image = button.isHighlighted ? highlightedImage : squareImage

--- a/DrawingApp/DrawingApp/View/ImageButton.swift
+++ b/DrawingApp/DrawingApp/View/ImageButton.swift
@@ -1,36 +1,36 @@
 //
-//  RectangleButton.swift
+//  ImageButton.swift
 //  DrawingApp
 //
-//  Created by 박진섭 on 2022/03/08.
+//  Created by 박진섭 on 2022/03/11.
 //
 
 import UIKit
 
 //button을 정의하는 코드가 너무 길어져서 ViewController에서 Button을 분리해서 선언했습니다.
-final class RectangleButton:UIButton {
+final class ImageButton:UIButton {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.frame = frame
-        configureRectangleButton()
-        configureRectangleButtonTapped()
+        configureImageButton()
+        configureImageButtonTapped()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         self.frame = frame
-        configureRectangleButton()
-        configureRectangleButtonTapped()
+        configureImageButton()
+        configureImageButtonTapped()
     }
     
     
     //사각형 추가 버튼
-    private func configureRectangleButton() {
+    private func configureImageButton() {
         self.tintColor = .black
         
         var configuration = UIButton.Configuration.plain()
-        configuration.title = "사각형"
+        configuration.title = "사진"
         
         configuration.imagePlacement = .top
         configuration.imagePadding = 20
@@ -45,9 +45,9 @@ final class RectangleButton:UIButton {
     
     
     //버튼 액션 - highLigted
-    private func configureRectangleButtonTapped() {
-        let squareImage = UIImage(systemName: "square")
-        let highlightedImage = UIImage(systemName: "square.fill")
+    private func configureImageButtonTapped() {
+        let squareImage = UIImage(systemName: "photo")
+        let highlightedImage = UIImage(systemName: "photo.fill")
         
         //사각형 버튼 터치시 변화를 보여주기 위해 선언함.
         self.configurationUpdateHandler = { button in

--- a/DrawingApp/DrawingApp/View/ImageRectangleView.swift
+++ b/DrawingApp/DrawingApp/View/ImageRectangleView.swift
@@ -1,23 +1,22 @@
 //
-//  PlaneRectangleView.swift
+//  ImageRectangleView.swift
 //  DrawingApp
 //
-//  Created by 박진섭 on 2022/03/05.
+//  Created by 박진섭 on 2022/03/16.
 //
 
 import UIKit
 
-
-final class PlaneRectangleView:UIView,RectangleViewable {
+class ImageRectanlgeView:UIImageView,RectangleViewable {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-    
+
     func setupFrameWithRectangle(rect:Rectangleable) {
         guard let planeRectangle = (rect as? PlaneRectangle) else { return }
         let x = planeRectangle.origin.x
@@ -26,19 +25,10 @@ final class PlaneRectangleView:UIView,RectangleViewable {
         let height = planeRectangle.size.height
         self.frame = CGRect(x: x, y: y, width: width, height: height)
     }
-
-    func setupBackGroundColor(rgb:RGB, alpha:Alpha) {
-        let red = rgb.red
-        let green = rgb.green
-        let blue = rgb.blue
-        self.backgroundColor = UIColor(
-            red: CGFloat(red) / 255,
-            green: CGFloat(green) / 255,
-            blue: CGFloat(blue) / 255,
-            alpha: CGFloat(alpha.value)
-        )
-    }
-
     
+    //image name for test
+    func setupImage(imageData:Data) {
+        self.image = UIImage(data: imageData)
+    }
     
 }

--- a/DrawingApp/DrawingApp/View/ImageRectangleView.swift
+++ b/DrawingApp/DrawingApp/View/ImageRectangleView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ImageRectanlgeView:UIImageView,RectangleViewable {
+final class ImageRectanlgeView:UIImageView,RectangleViewable {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -26,7 +26,6 @@ class ImageRectanlgeView:UIImageView,RectangleViewable {
         self.frame = CGRect(x: x, y: y, width: width, height: height)
     }
     
-    //image name for test
     func setupImage(imageData:Data) {
         self.image = UIImage(data: imageData)
     }

--- a/DrawingApp/DrawingApp/View/PlaneRectangleView.swift
+++ b/DrawingApp/DrawingApp/View/PlaneRectangleView.swift
@@ -38,7 +38,4 @@ final class PlaneRectangleView:UIView,RectangleViewable {
             alpha: CGFloat(alpha.value)
         )
     }
-
-    
-    
 }

--- a/DrawingApp/DrawingApp/View/PlaneRectangleView.swift
+++ b/DrawingApp/DrawingApp/View/PlaneRectangleView.swift
@@ -1,5 +1,5 @@
 //
-//  RectangleView.swift
+//  PlaneRectangleView.swift
 //  DrawingApp
 //
 //  Created by 박진섭 on 2022/03/05.
@@ -7,9 +7,9 @@
 
 import UIKit
 
-final class RectangleView:UIView {
+final class PlaneRectangleView:UIView {
     
-    convenience init(rect: Rectangle, rgb:RGB, alpha:Alpha) {
+    convenience init(rect: PlaneRectangle, rgb:RGB, alpha:Alpha) {
         let x = rect.origin.x
         let y = rect.origin.y
         

--- a/DrawingApp/DrawingApp/View/PlaneRectangleView.swift
+++ b/DrawingApp/DrawingApp/View/PlaneRectangleView.swift
@@ -7,22 +7,38 @@
 
 import UIKit
 
+
 final class PlaneRectangleView:UIView {
     
-    convenience init(rect: PlaneRectangle, rgb:RGB, alpha:Alpha) {
-        let x = rect.origin.x
-        let y = rect.origin.y
-        
-        let width = rect.size.width
-        let height = rect.size.height
-        
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    func setupFrameWithPlaneRectangle(rect:Rectangle) {
+        guard let planeRectangle = rect as? PlaneRectangle else { return }
+        let x = planeRectangle.origin.x
+        let y = planeRectangle.origin.y
+        let width = planeRectangle.size.width
+        let height = planeRectangle.size.height
+        self.frame = CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    func setupBackGroundColor(rgb:RGB, alpha:Alpha) {
         let red = rgb.red
         let green = rgb.green
         let blue = rgb.blue
-        
-        let alpha = alpha.value
-        
-        self.init(frame: CGRect(x: x, y: y, width: width, height: height))
-        self.backgroundColor = UIColor(red: CGFloat(red) / 255, green: CGFloat(green) / 255, blue: CGFloat(blue) / 255, alpha: CGFloat(alpha))
+        self.backgroundColor = UIColor(
+            red: CGFloat(red) / 255,
+            green: CGFloat(green) / 255,
+            blue: CGFloat(blue) / 255,
+            alpha: CGFloat(alpha.value)
+        )
     }
+
+    
+    
 }

--- a/DrawingApp/DrawingAppTests/DrawingAppTests.swift
+++ b/DrawingApp/DrawingAppTests/DrawingAppTests.swift
@@ -25,7 +25,7 @@ class DrawingAppTests: XCTestCase {
         let alpha = Alpha(1.2)
 
         let testRectangle = PlaneRectangle(id: id, origin: point, size: size, rgb: rgb, alpha: alpha)
-        sut.addRectangle(rectangle: testRectangle)
+        sut.addRectangle(creator: RectangleFactory())
         sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y), size: size)
         
         let testAlpha = Alpha(2.3)
@@ -37,15 +37,9 @@ class DrawingAppTests: XCTestCase {
     
     
     func testChangeColor() {
-        let id = IDFactory.makeRandomID()
-        let size = Size(width: 150, height: 120)
-        let point = Point.random()
-        let rgb = RGB(red: 10, green: 10, blue: 10)
-        let alpha = Alpha.random()
+        let testRectangle = sut.addRectangle(creator: RectangleFactory())
         
-        let testRectangle = PlaneRectangle(id: id, origin: point, size: size, rgb: rgb, alpha: alpha)
-        sut.addRectangle(rectangle: testRectangle)
-        sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y), size: size)
+        sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y), size: testRectangle.size)
         
         let testRGB = RGB(red: 10, green: 11, blue: 12)
         sut.change(color: testRGB)
@@ -54,45 +48,27 @@ class DrawingAppTests: XCTestCase {
     }
     
     func testAddRectangle() {
-        let id = IDFactory.makeRandomID()
-        let size = Size(width: 150, height: 120)
-        let point = Point.random()
-        let rgb = RGB.random()
-        let alpha = Alpha.random()
-        
-        let testRectangle = PlaneRectangle(id: id, origin: point, size: size, rgb: rgb, alpha: alpha)
-        
-        sut.addRectangle(rectangle: testRectangle)
-        
+        sut.addRectangle(creator: RectangleFactory())
         XCTAssertTrue(sut.count == 1)
     }
     
     
-    func testFindSeletedRectangle() {
-        let id = IDFactory.makeRandomID()
-        let size = Size(width: 150, height: 120)
-        let point = Point(x: 10.0, y: 10.0)
-        let rgb = RGB.random()
-        let alpha = Alpha(0.5)
-
-        let testRectangle = PlaneRectangle(id: id, origin: point, size: size, rgb: rgb, alpha: alpha)
-        let x = round(testRectangle.origin.x)
-        let y = round(testRectangle.origin.y)
-
-        sut.addRectangle(rectangle: testRectangle)
+    func testFindSelectedRectangle() {
+        
+        let willSeletedRectangle = sut.addRectangle(creator: RectangleFactory())
+        let TestRaectangle = sut.addRectangle(creator: RectangleFactory())
+        
+        let x = round(willSeletedRectangle.origin.x)
+        let y = round(willSeletedRectangle.origin.y)
+        let size = willSeletedRectangle.size
         
         let correctKey = Point(x: x, y: y)
-        let inCorrectKey = Point(x: 12.456, y: 15.234)
 
         sut.findSeletedRectangle(x: correctKey.x, y: correctKey.y, size: size)
-        sut.change(alpha: Alpha(0.1))
         
-        XCTAssertTrue(testRectangle.alpha == Alpha(0.1))
+        sut.change(alpha:Alpha(0.7))
         
-        sut.findSeletedRectangle(x: inCorrectKey.x, y: inCorrectKey.y, size: size)
-        sut.change(alpha: Alpha(0.7))
-        
-        XCTAssertFalse(testRectangle.alpha == Alpha(0.7))
+        XCTAssertEqual(willSeletedRectangle.alpha, Alpha(0.7))
     }
     
     

--- a/DrawingApp/DrawingAppTests/DrawingAppTests.swift
+++ b/DrawingApp/DrawingAppTests/DrawingAppTests.swift
@@ -18,15 +18,8 @@ class DrawingAppTests: XCTestCase {
     }
 
     func testChangeAlpha() {
-        let id = IDFactory.makeRandomID()
-        let size = Size(width: 150, height: 120)
-        let point = Point.random()
-        let rgb = RGB.random()
-        let alpha = Alpha(1.2)
-
-        let testRectangle = PlaneRectangle(id: id, origin: point, size: size, rgb: rgb, alpha: alpha)
-        sut.addRectangle(creator: RectangleFactory())
-        sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y), size: size)
+        let testRectangle = sut.addRectangle(creator: RectangleFactory())
+        sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y), size: testRectangle.size)
         
         let testAlpha = Alpha(2.3)
         sut.change(alpha: testAlpha)

--- a/DrawingApp/DrawingAppTests/DrawingAppTests.swift
+++ b/DrawingApp/DrawingAppTests/DrawingAppTests.swift
@@ -22,33 +22,35 @@ class DrawingAppTests: XCTestCase {
         let size = Size(width: 150, height: 120)
         let point = Point.random()
         let rgb = RGB.random()
-        let alpha = Alpha.random()
-        
+        let alpha = Alpha(1.2)
+
         let testRectangle = Rectangle(id: id, origin: point, size: size, backGroundColor: rgb, alpha: alpha)
+        sut.addRectangle(rectangle: testRectangle)
+        sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y))
         
-        sut.selectedRectangle = testRectangle
         let testAlpha = Alpha(2.3)
-        
         sut.change(alpha: testAlpha)
-        
-        XCTAssertEqual(sut.selectedRectangle!.alpha, testAlpha)
+
+        XCTAssertEqual(testRectangle.alpha, testAlpha)
     }
+
+    
     
     func testChangeColor() {
         let id = IDFactory.makeRandomID()
         let size = Size(width: 150, height: 120)
         let point = Point.random()
-        let rgb = RGB.random()
+        let rgb = RGB(red: 10, green: 10, blue: 10)
         let alpha = Alpha.random()
         
         let testRectangle = Rectangle(id: id, origin: point, size: size, backGroundColor: rgb, alpha: alpha)
+        sut.addRectangle(rectangle: testRectangle)
+        sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y))
         
-        sut.selectedRectangle = testRectangle
         let testRGB = RGB(red: 10, green: 11, blue: 12)
-        
         sut.change(color: testRGB)
         
-        XCTAssertEqual(sut.selectedRectangle!.rgb, testRGB)
+        XCTAssertEqual(testRectangle.rgb, testRGB)
     }
     
     func testAddRectangle() {
@@ -62,32 +64,35 @@ class DrawingAppTests: XCTestCase {
         
         sut.addRectangle(rectangle: testRectangle)
         
-        XCTAssertTrue(sut.rectangles.count == 1)
+        XCTAssertTrue(sut.count == 1)
     }
     
     
     func testFindSeletedRectangle() {
         let id = IDFactory.makeRandomID()
         let size = Size(width: 150, height: 120)
-        let point = Point.random()
+        let point = Point(x: 10.0, y: 10.0)
         let rgb = RGB.random()
-        let alpha = Alpha.random()
-        
+        let alpha = Alpha(0.5)
+
         let testRectangle = Rectangle(id: id, origin: point, size: size, backGroundColor: rgb, alpha: alpha)
         let x = round(testRectangle.origin.x)
         let y = round(testRectangle.origin.y)
+
+        sut.addRectangle(rectangle: testRectangle)
         
         let correctKey = Point(x: x, y: y)
         let inCorrectKey = Point(x: 12.456, y: 15.234)
+
+        sut.findSeletedRectangle(x: correctKey.x, y: correctKey.y)
+        sut.change(alpha: Alpha(0.1))
         
-        sut.rectangles[correctKey] = testRectangle
-        sut.findSeletedRectangle(x: x, y: y)
+        XCTAssertTrue(testRectangle.alpha == Alpha(0.1))
         
-        let shouldTrue = sut.selectedRectangle == sut.rectangles[correctKey]
-        let shouldFalse = sut.selectedRectangle == sut.rectangles[inCorrectKey]
+        sut.findSeletedRectangle(x: inCorrectKey.x, y: inCorrectKey.y)
+        sut.change(alpha: Alpha(0.7))
         
-        XCTAssertTrue(shouldTrue)
-        XCTAssertFalse(shouldFalse)
+        XCTAssertFalse(testRectangle.alpha == Alpha(0.7))
     }
     
     

--- a/DrawingApp/DrawingAppTests/DrawingAppTests.swift
+++ b/DrawingApp/DrawingAppTests/DrawingAppTests.swift
@@ -24,9 +24,9 @@ class DrawingAppTests: XCTestCase {
         let rgb = RGB.random()
         let alpha = Alpha(1.2)
 
-        let testRectangle = Rectangle(id: id, origin: point, size: size, backGroundColor: rgb, alpha: alpha)
+        let testRectangle = PlaneRectangle(id: id, origin: point, size: size, rgb: rgb, alpha: alpha)
         sut.addRectangle(rectangle: testRectangle)
-        sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y))
+        sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y), size: size)
         
         let testAlpha = Alpha(2.3)
         sut.change(alpha: testAlpha)
@@ -43,9 +43,9 @@ class DrawingAppTests: XCTestCase {
         let rgb = RGB(red: 10, green: 10, blue: 10)
         let alpha = Alpha.random()
         
-        let testRectangle = Rectangle(id: id, origin: point, size: size, backGroundColor: rgb, alpha: alpha)
+        let testRectangle = PlaneRectangle(id: id, origin: point, size: size, rgb: rgb, alpha: alpha)
         sut.addRectangle(rectangle: testRectangle)
-        sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y))
+        sut.findSeletedRectangle(x: round(testRectangle.origin.x), y: round(testRectangle.origin.y), size: size)
         
         let testRGB = RGB(red: 10, green: 11, blue: 12)
         sut.change(color: testRGB)
@@ -60,7 +60,7 @@ class DrawingAppTests: XCTestCase {
         let rgb = RGB.random()
         let alpha = Alpha.random()
         
-        let testRectangle = Rectangle(id: id, origin: point, size: size, backGroundColor: rgb, alpha: alpha)
+        let testRectangle = PlaneRectangle(id: id, origin: point, size: size, rgb: rgb, alpha: alpha)
         
         sut.addRectangle(rectangle: testRectangle)
         
@@ -75,7 +75,7 @@ class DrawingAppTests: XCTestCase {
         let rgb = RGB.random()
         let alpha = Alpha(0.5)
 
-        let testRectangle = Rectangle(id: id, origin: point, size: size, backGroundColor: rgb, alpha: alpha)
+        let testRectangle = PlaneRectangle(id: id, origin: point, size: size, rgb: rgb, alpha: alpha)
         let x = round(testRectangle.origin.x)
         let y = round(testRectangle.origin.y)
 
@@ -84,12 +84,12 @@ class DrawingAppTests: XCTestCase {
         let correctKey = Point(x: x, y: y)
         let inCorrectKey = Point(x: 12.456, y: 15.234)
 
-        sut.findSeletedRectangle(x: correctKey.x, y: correctKey.y)
+        sut.findSeletedRectangle(x: correctKey.x, y: correctKey.y, size: size)
         sut.change(alpha: Alpha(0.1))
         
         XCTAssertTrue(testRectangle.alpha == Alpha(0.1))
         
-        sut.findSeletedRectangle(x: inCorrectKey.x, y: inCorrectKey.y)
+        sut.findSeletedRectangle(x: inCorrectKey.x, y: inCorrectKey.y, size: size)
         sut.change(alpha: Alpha(0.7))
         
         XCTAssertFalse(testRectangle.alpha == Alpha(0.7))


### PR DESCRIPTION
- 작업내용
- [X] 이미지 추가 버튼 추가
- [X] Step3 MainViewController에서  self.view 찾는 입출력 분리 -> 처리로직 Plane으로 이전
- [X] Plane안 프로퍼티 Private로 선언
- [X] Plane 프로퍼티들이 Private로 됨에 따라 test코드 리팩토링.
- [X] Rectangle Protocol선언 및 Factory 선언
- [X] Factory 메서드에서 Case 처리를 위해 Enum이 아닌 ObjectIdentifier 시도.
- [ ] 이미지 추가 버튼 액션 구현
- [ ] 사진데이터 처리 관리 뷰또는 뷰모델 선언

- - -
키워드: ObjectIdentifier, Factory, creator

고민 및 해결:
- Plane의  property들을 private접근자로 바꾸어주었습니다.
이 과정에서 test에서 프로퍼티를 이용해서 하던 로직들을 수정해야했는데,
예를 들어 선택된 사각형의 alpha값을 바꾸는 로직은 Plane에 선택된 사각형이 있어야만 테스트가 가능한데, Plane의 선택된 사각형을 참조할 수 없으므로 직접적으로 Plane에 테스트용 선택된 사각형을 넣어줄 방법이 없어서 Plane에 있는 add메서드와 findRectangle메소드를 이용해 테스트틑 했습니다.

- 빈화면을 클릭시 사각형의 선택을 없애는 로직을 짜야했습니다.
이전에는 ViewController에서 터치한 곳이 view이면 취소되게 하면 됐으나 이또한 출력이라 생각하고 분리를 해야한다면,
`터치한곳이 Rectangle인지 빈화면인지 구분을 어떻게 할까?`에 대한 고민이 있었습니다.

1. `Point(0.0,0.0)이면 빈화면으로 하자.`
 당시 사각형을 판별하기 위해 key 값을 origin.x와 origin.y로 구성하여 Plane에게 전달하는데 self.view는 origin값이 항상 Point(0.0,0.0) 
 하지만 , 랜덤으로 생성된 사각형이 0.0좌표에 생길 수 있으므로 다른 방법이 필요하거나 추가적인 구분할 요소가 필요.

2. `Size매개변수를 하나더 생성`후 plane에서 선택한 View의 size가 최대 크기이면 빈화면을 클릭한것으로 판단하고 로직을 구성

- - -
질문거리:
1. 빈화면 클릭시 사각형을 없애는 로직을 구성하다가,
Plane에서 같은 NotificationName을 가진 Post를 두번하게 되었는데.. 이 과정이 어색하다면 코멘트 남겨주시면 감사하겠습니다!

2. 수업시간에 배운 Protocol과 Factory를 연결하여 설계하던중 `Enum Switch Case`문 대신 `ObjectIdentifier`를 시도해보았습니다
그 결과,,
Enum혹은 타입을 더 선언 안해도 되지만, ViewController에서 `.`을 통한 네임스페이스 기능을 사용하지는 못하였습니다.
만약, 코드를 짠 제가아닌 다른 사용자가 이를 이용하려한다면 조금 불편할 수 있겠다는 생각이 들었습니다.
(물론 메서드나 프로퍼티명을 아주 명확하게 지으면 해결이 될수도 있겠지만..)
이는 Factory안에 Switch 해야하는 Case문이 점차 많아질 수록 한눈에 보기 편한 Enum으로 인한 Switch문이 더 나아 보인다는 생각이 듭니다!
ObjectIdentifier를 이용한 코드를 처음 짜봐서 제가 잘 못 사용한 부분이나, 위의 문제점을 해결할 수 있는 방법이 있다면 코멘트 해주시면 감사하겠습니다!! 
