### PR TITLE
[Sol] Step3-04 사진 추가하기 기능 구현

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		02D5541827CC5FF200291B27 /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D5541727CC5FF200291B27 /* Size.swift */; };
 		02D5541A27CC606300291B27 /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D5541927CC606300291B27 /* Point.swift */; };
 		02D5541C27CC6CE100291B27 /* BackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D5541B27CC6CE100291B27 /* BackgroundColor.swift */; };
+		02F8198B27DEE9B70084F0AD /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F8198A27DEE9B70084F0AD /* Photo.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +58,7 @@
 		02D5541727CC5FF200291B27 /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
 		02D5541927CC606300291B27 /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
 		02D5541B27CC6CE100291B27 /* BackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundColor.swift; sourceTree = "<group>"; };
+		02F8198A27DEE9B70084F0AD /* Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +102,7 @@
 				0200342D27D0837F0032EEA4 /* Plane.swift */,
 				02A7161B27CCF63C00034A70 /* RectangleFactory.swift */,
 				02D5541527CC5FB000291B27 /* Rectangle.swift */,
+				02F8198A27DEE9B70084F0AD /* Photo.swift */,
 				02B9D2A027CF37E600A7185E /* id.swift */,
 				02D5541B27CC6CE100291B27 /* BackgroundColor.swift */,
 				02D5541727CC5FF200291B27 /* Size.swift */,
@@ -253,6 +256,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				02F8198B27DEE9B70084F0AD /* Photo.swift in Sources */,
 				02D5540627CC5E7D00291B27 /* ViewController.swift in Sources */,
 				02D5541827CC5FF200291B27 /* Size.swift in Sources */,
 				02D5541A27CC606300291B27 /* Point.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		02D5541A27CC606300291B27 /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D5541927CC606300291B27 /* Point.swift */; };
 		02D5541C27CC6CE100291B27 /* BackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D5541B27CC6CE100291B27 /* BackgroundColor.swift */; };
 		02F8198B27DEE9B70084F0AD /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F8198A27DEE9B70084F0AD /* Photo.swift */; };
+		02F8198D27DEEBA00084F0AD /* PhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F8198C27DEEBA00084F0AD /* PhotoView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +60,7 @@
 		02D5541927CC606300291B27 /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
 		02D5541B27CC6CE100291B27 /* BackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundColor.swift; sourceTree = "<group>"; };
 		02F8198A27DEE9B70084F0AD /* Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
+		02F8198C27DEEBA00084F0AD /* PhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				023A3A4027D2F45100F56686 /* RectangleView.swift */,
+				02F8198C27DEEBA00084F0AD /* PhotoView.swift */,
 			);
 			name = View;
 			path = DrawingApp/View;
@@ -259,6 +262,7 @@
 				02F8198B27DEE9B70084F0AD /* Photo.swift in Sources */,
 				02D5540627CC5E7D00291B27 /* ViewController.swift in Sources */,
 				02D5541827CC5FF200291B27 /* Size.swift in Sources */,
+				02F8198D27DEEBA00084F0AD /* PhotoView.swift in Sources */,
 				02D5541A27CC606300291B27 /* Point.swift in Sources */,
 				02D5540227CC5E7D00291B27 /* AppDelegate.swift in Sources */,
 				02D5540427CC5E7D00291B27 /* SceneDelegate.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		02D5541C27CC6CE100291B27 /* BackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D5541B27CC6CE100291B27 /* BackgroundColor.swift */; };
 		02F8198B27DEE9B70084F0AD /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F8198A27DEE9B70084F0AD /* Photo.swift */; };
 		02F8198D27DEEBA00084F0AD /* PhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F8198C27DEEBA00084F0AD /* PhotoView.swift */; };
+		02F8199527E06F810084F0AD /* AnyRectangularable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F8199427E06F800084F0AD /* AnyRectangularable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +62,7 @@
 		02D5541B27CC6CE100291B27 /* BackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundColor.swift; sourceTree = "<group>"; };
 		02F8198A27DEE9B70084F0AD /* Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
 		02F8198C27DEEBA00084F0AD /* PhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoView.swift; sourceTree = "<group>"; };
+		02F8199427E06F800084F0AD /* AnyRectangularable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyRectangularable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,6 +106,7 @@
 			children = (
 				0200342D27D0837F0032EEA4 /* Plane.swift */,
 				02A7161B27CCF63C00034A70 /* RectangleFactory.swift */,
+				02F8199427E06F800084F0AD /* AnyRectangularable.swift */,
 				02D5541527CC5FB000291B27 /* Rectangle.swift */,
 				02F8198A27DEE9B70084F0AD /* Photo.swift */,
 				02B9D2A027CF37E600A7185E /* id.swift */,
@@ -266,6 +269,7 @@
 				02D5541A27CC606300291B27 /* Point.swift in Sources */,
 				02D5540227CC5E7D00291B27 /* AppDelegate.swift in Sources */,
 				02D5540427CC5E7D00291B27 /* SceneDelegate.swift in Sources */,
+				02F8199527E06F810084F0AD /* AnyRectangularable.swift in Sources */,
 				02B9D29F27CF033B00A7185E /* Alpha.swift in Sources */,
 				02D5541627CC5FB000291B27 /* Rectangle.swift in Sources */,
 				02B9D2A127CF37E600A7185E /* id.swift in Sources */,

--- a/DrawingApp/DrawingApp/Model/AnyRectangularable.swift
+++ b/DrawingApp/DrawingApp/Model/AnyRectangularable.swift
@@ -1,0 +1,64 @@
+//
+//  AnyRectangularable.swift
+//  DrawingApp
+//
+//  Created by 김한솔 on 2022/03/15.
+//
+
+import Foundation
+
+protocol Rectangularable {
+    var id: ID {get}
+    var size: Size {get}
+    var point: Point {get}
+    var alpha: Alpha {get}
+    var backgroundColorButtonShouldBecomeHidden: Bool {get}
+    func isPointInArea(_ point: Point) -> Bool
+    func changeAlphaValue(to newAlpha: Alpha)
+}
+
+class AnyRectangularable: Rectangularable {
+    private(set) var id: ID
+    private(set) var size: Size
+    private(set) var point: Point
+    private(set) var alpha: Alpha
+    
+    var backgroundColorButtonShouldBecomeHidden: Bool {
+        return false
+    }
+    
+    init(size: Size, point: Point, alpha: Alpha) {
+        self.id = ID()
+        self.size = size
+        self.point = point
+        self.alpha = alpha
+    }
+    
+    func isPointInArea(_ point: Point) -> Bool {
+        return point.x >= self.point.x && point.x <= self.point.x + self.size.width &&
+            point.y >= self.point.y && point.y <= self.point.y + self.size.height
+    }
+    
+    func changeAlphaValue(to newAlpha: Alpha) {
+        self.alpha = newAlpha
+    }
+
+}
+
+extension AnyRectangularable: CustomStringConvertible {
+    var description: String {
+        return "\(id) Rectangle, \(point), \(size), \(alpha)"
+    }
+}
+
+extension AnyRectangularable: Equatable {
+    static func == (lhs: AnyRectangularable, rhs: AnyRectangularable) -> Bool {
+        return lhs === rhs
+    }
+}
+
+extension AnyRectangularable: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self)
+    }
+}

--- a/DrawingApp/DrawingApp/Model/AnyRectangularable.swift
+++ b/DrawingApp/DrawingApp/Model/AnyRectangularable.swift
@@ -59,6 +59,6 @@ extension AnyRectangularable: Equatable {
 
 extension AnyRectangularable: Hashable {
     func hash(into hasher: inout Hasher) {
-        hasher.combine(self)
+        hasher.combine(self.id)
     }
 }

--- a/DrawingApp/DrawingApp/Model/BackgroundColor.swift
+++ b/DrawingApp/DrawingApp/Model/BackgroundColor.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct BackgroundColor: Equatable {
-    let r: Int
-    let g: Int
-    let b: Int
-    static let possibleColorValues = 0...255
+    let r: UInt8
+    let g: UInt8
+    let b: UInt8
+    static let possibleColorValues = UInt8(0)...UInt8(255)
     var hexCode: String {
         let hexR = String(Int(r), radix: 16).uppercased()
         let hexG = String(Int(g), radix: 16).uppercased()
@@ -20,28 +20,18 @@ struct BackgroundColor: Equatable {
         return "#\(hexR)\(hexG)\(hexB)"
     }
     
-    init?(r: Int, g: Int, b: Int) {
-        let colorValues = [r, g, b]
-        let min = BackgroundColor.possibleColorValues.min() ?? 0
-        let max = BackgroundColor.possibleColorValues.max() ?? 255
-        
-        for colorValue in colorValues {
-            if colorValue > max || colorValue < min {
-                return nil
-            }
-        }
-        
-        self.r = colorValues[0]
-        self.g = colorValues[1]
-        self.b = colorValues[2]
+    init(r: UInt8, g: UInt8, b: UInt8) {
+        self.r = r
+        self.g = g
+        self.b = b
     }
     
     static func random() -> BackgroundColor {
-        let randomR = Int.random(in: possibleColorValues)
-        let randomG = Int.random(in: possibleColorValues)
-        let randomB = Int.random(in: possibleColorValues)
+        let randomR = UInt8.random(in: possibleColorValues)
+        let randomG = UInt8.random(in: possibleColorValues)
+        let randomB = UInt8.random(in: possibleColorValues)
         
-        return BackgroundColor(r: randomR, g: randomG, b: randomB) ?? BackgroundColor(r: 0, g: 0, b: 0)!
+        return BackgroundColor(r: randomR, g: randomG, b: randomB)
     }
 
 }

--- a/DrawingApp/DrawingApp/Model/BackgroundColor.swift
+++ b/DrawingApp/DrawingApp/Model/BackgroundColor.swift
@@ -11,7 +11,6 @@ struct BackgroundColor: Equatable {
     let r: UInt8
     let g: UInt8
     let b: UInt8
-    static let possibleColorValues = UInt8(0)...UInt8(255)
     var hexCode: String {
         let hexR = String(Int(r), radix: 16).uppercased()
         let hexG = String(Int(g), radix: 16).uppercased()
@@ -27,9 +26,9 @@ struct BackgroundColor: Equatable {
     }
     
     static func random() -> BackgroundColor {
-        let randomR = UInt8.random(in: possibleColorValues)
-        let randomG = UInt8.random(in: possibleColorValues)
-        let randomB = UInt8.random(in: possibleColorValues)
+        let randomR = UInt8.random(in: UInt8.min...UInt8.max)
+        let randomG = UInt8.random(in: UInt8.min...UInt8.max)
+        let randomB = UInt8.random(in: UInt8.min...UInt8.max)
         
         return BackgroundColor(r: randomR, g: randomG, b: randomB)
     }

--- a/DrawingApp/DrawingApp/Model/Photo.swift
+++ b/DrawingApp/DrawingApp/Model/Photo.swift
@@ -7,15 +7,19 @@
 
 import Foundation
 
-class Photo: Rectangle {
+protocol imageDataHavable {
+    var image: Data {get}
+}
+
+class Photo: AnyRectangularable, imageDataHavable {
     private(set) var image: Data
     
-    init(id: ID, size: Size, point: Point, image: Data, alpha: Alpha) {
-        self.image = image
-        super.init(id: id, size: size, point: point, backgroundColor: BackgroundColor.init(r: 0, g: 0, b: 0), alpha: alpha)
+    override var backgroundColorButtonShouldBecomeHidden: Bool {
+        return true
     }
     
-    override func backgroundColorButtonShouldBecomeHidden() -> Bool {
-        return true
+    init(size: Size, point: Point, image: Data, alpha: Alpha) {
+        self.image = image
+        super.init(size: size, point: point, alpha: alpha)
     }
 }

--- a/DrawingApp/DrawingApp/Model/Photo.swift
+++ b/DrawingApp/DrawingApp/Model/Photo.swift
@@ -14,4 +14,8 @@ class Photo: Rectangle {
         self.image = image
         super.init(id: id, size: size, point: point, backgroundColor: BackgroundColor.init(r: 0, g: 0, b: 0), alpha: alpha)
     }
+    
+    override func backgroundColorButtonShouldBecomeHidden() -> Bool {
+        return true
+    }
 }

--- a/DrawingApp/DrawingApp/Model/Photo.swift
+++ b/DrawingApp/DrawingApp/Model/Photo.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import UIKit
 
 class Photo: Rectangularable {
     private let id: ID
@@ -14,7 +13,7 @@ class Photo: Rectangularable {
     private(set) var point: Point
     private(set) var backgroundColor: BackgroundColor
     private(set) var alpha: Alpha
-    private(set) var image: UIImage
+    private(set) var image: Data
     
     func isPointInArea(_ point: Point) -> Bool {
         return point.x >= self.point.x && point.x <= self.point.x + self.size.width &&
@@ -29,7 +28,7 @@ class Photo: Rectangularable {
         self.alpha = newAlpha
     }
     
-    init(id: ID, size: Size, point: Point, image: UIImage, alpha: Alpha) {
+    init(id: ID, size: Size, point: Point, image: Data, alpha: Alpha) {
         self.id = id
         self.size = size
         self.point = point

--- a/DrawingApp/DrawingApp/Model/Photo.swift
+++ b/DrawingApp/DrawingApp/Model/Photo.swift
@@ -7,51 +7,11 @@
 
 import Foundation
 
-class Photo: Rectangularable {
-    private let id: ID
-    private(set) var size: Size
-    private(set) var point: Point
-    private(set) var backgroundColor: BackgroundColor
-    private(set) var alpha: Alpha
+class Photo: Rectangle {
     private(set) var image: Data
     
-    func isPointInArea(_ point: Point) -> Bool {
-        return point.x >= self.point.x && point.x <= self.point.x + self.size.width &&
-        point.y >= self.point.y && self.point.y <= self.point.y + self.size.height
-    }
-    
-    func changeBackgroundColor(to newColor: BackgroundColor) {
-        self.backgroundColor = newColor
-    }
-    
-    func changeAlphaValue(to newAlpha: Alpha) {
-        self.alpha = newAlpha
-    }
-    
     init(id: ID, size: Size, point: Point, image: Data, alpha: Alpha) {
-        self.id = id
-        self.size = size
-        self.point = point
-        self.alpha = alpha
         self.image = image
-        self.backgroundColor = BackgroundColor.init(r: 0, g: 0, b: 0)
-    }
-}
-
-extension Photo: CustomStringConvertible {
-    var description: String {
-        return id.description
-    }
-}
-
-extension Photo: Equatable {
-    static func == (lhs: Photo, rhs: Photo) -> Bool {
-        return lhs.id == rhs.id
-    }
-}
-
-extension Photo: Hashable {
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
+        super.init(id: id, size: size, point: point, backgroundColor: BackgroundColor.init(r: 0, g: 0, b: 0), alpha: alpha)
     }
 }

--- a/DrawingApp/DrawingApp/Model/Photo.swift
+++ b/DrawingApp/DrawingApp/Model/Photo.swift
@@ -1,0 +1,58 @@
+//
+//  Photo.swift
+//  DrawingApp
+//
+//  Created by 김한솔 on 2022/03/14.
+//
+
+import Foundation
+import UIKit
+
+class Photo: Rectangularable {
+    private let id: ID
+    private(set) var size: Size
+    private(set) var point: Point
+    private(set) var backgroundColor: BackgroundColor
+    private(set) var alpha: Alpha
+    private(set) var image: UIImage
+    
+    func isPointInArea(_ point: Point) -> Bool {
+        return point.x >= self.point.x && point.x <= self.point.x + self.size.width &&
+        point.y >= self.point.y && self.point.y <= self.point.y + self.size.height
+    }
+    
+    func changeBackgroundColor(to newColor: BackgroundColor) {
+        self.backgroundColor = newColor
+    }
+    
+    func changeAlphaValue(to newAlpha: Alpha) {
+        self.alpha = newAlpha
+    }
+    
+    init(id: ID, size: Size, point: Point, image: UIImage, alpha: Alpha) {
+        self.id = id
+        self.size = size
+        self.point = point
+        self.alpha = alpha
+        self.image = image
+        self.backgroundColor = BackgroundColor.init(r: 0, g: 0, b: 0)
+    }
+}
+
+extension Photo: CustomStringConvertible {
+    var description: String {
+        return id.description
+    }
+}
+
+extension Photo: Equatable {
+    static func == (lhs: Photo, rhs: Photo) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
+extension Photo: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -28,25 +28,22 @@ class Plane {
         return rectangles.count
     }
     
-    subscript(_ point: Point) -> Rectangularable? {
-        for rectangle in rectangles.reversed() {
-            if rectangle.isPointInArea(point) {
-                return rectangle
-            }
-        }
-        return nil
+    subscript(_ index: Int) -> Rectangularable? {
+        return rectangles[index]
     }
     
     public func specifyRectangle(point: Point) -> Result<Rectangularable, PlaneError> {
-        guard let specifiedRectangle = self[point] else {
-            self.specifiedRectangle = nil
-            notificationCenter.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self)
-            return .failure(.cannotSpecifyRectangleError)
+        for rectangle in rectangles.reversed() {
+            if rectangle.isPointInArea(point) {
+                self.specifiedRectangle = rectangle
+                notificationCenter.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self, userInfo: [Plane.UserIDKeys.specifiedRectangle: rectangle])
+                return .success(rectangle)
+            }
         }
+        self.specifiedRectangle = nil
+        notificationCenter.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self)
+        return .failure(.cannotSpecifyRectangleError)
         
-        self.specifiedRectangle = specifiedRectangle
-        notificationCenter.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self, userInfo: [Plane.UserIDKeys.specifiedRectangle: specifiedRectangle])
-        return .success(specifiedRectangle)
     }
     
     public func addNewRectangle(in frame: (width: Double, height: Double)) {

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -10,15 +10,17 @@ import Foundation
 class Plane {
     struct NotificationNames {
         static let didAddRectangle = Notification.Name("PlaneDidAddRectangle")
+        static let didAddPhoto = Notification.Name("PlaneDidAddPhoto")
         static let didSpecifyRectangle = Notification.Name("PlaneDidSpecifyRectangle")
         static let didChangeRectangleBackgroundColor = Notification.Name("PlaneDidChangeRectangleBackgroundColor")
         static let didChangeRectangleAlpha = Notification.Name("PlaneDidChangeRectangleAlpha")
     }
     
-    struct UserIDKeys {
+    struct UserInfoKeys {
         static let changedRectangle = "changedRectangle"
         static let specifiedRectangle = "specifiedRectangle"
         static let addedRectangle = "addedRectangle"
+        static let addedPhoto = "addedPhoto"
     }
     
     private var rectangles = [Rectangularable]()
@@ -35,7 +37,7 @@ class Plane {
         for rectangle in rectangles.reversed() {
             if rectangle.isPointInArea(point) {
                 self.specifiedRectangle = rectangle
-                NotificationCenter.default.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self, userInfo: [Plane.UserIDKeys.specifiedRectangle: rectangle])
+                NotificationCenter.default.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self, userInfo: [Plane.UserInfoKeys.specifiedRectangle: rectangle])
                 return .success(rectangle)
             }
         }
@@ -48,7 +50,13 @@ class Plane {
     public func addNewRectangle(in frame: (width: Double, height: Double)) {
         let newRectangle = RectangleFactory.makeRandomRectangle(in: frame)
         rectangles.append(newRectangle)
-        NotificationCenter.default.post(name: Plane.NotificationNames.didAddRectangle, object: self, userInfo: [Plane.UserIDKeys.addedRectangle: newRectangle])
+        NotificationCenter.default.post(name: Plane.NotificationNames.didAddRectangle, object: self, userInfo: [Plane.UserInfoKeys.addedRectangle: newRectangle])
+    }
+    
+    public func addNewPhoto(in frame: (width: Double, height: Double), with newImage: Data) {
+        let newPhoto = RectangleFactory.makePhoto(in: frame, image: newImage)
+        rectangles.append(newPhoto)
+        NotificationCenter.default.post(name: Plane.NotificationNames.didAddPhoto, object: self, userInfo: [Plane.UserInfoKeys.addedPhoto: newPhoto])
     }
     
     public func changeBackgroundColor(to newColor: BackgroundColor) -> Result<Rectangularable, PlaneError> {
@@ -56,7 +64,7 @@ class Plane {
             return .failure(.noSpecifiedRectangleToChangeError)
         }
         specifiedRectangle.changeBackgroundColor(to: newColor)
-        NotificationCenter.default.post(name: Plane.NotificationNames.didChangeRectangleBackgroundColor, object: self, userInfo: [Plane.UserIDKeys.changedRectangle: specifiedRectangle])
+        NotificationCenter.default.post(name: Plane.NotificationNames.didChangeRectangleBackgroundColor, object: self, userInfo: [Plane.UserInfoKeys.changedRectangle: specifiedRectangle])
         return .success(specifiedRectangle)
     }
 
@@ -65,7 +73,7 @@ class Plane {
             return .failure(.noSpecifiedRectangleToChangeError)
         }
         specifiedRectangle.changeAlphaValue(to: newAlpha)
-        NotificationCenter.default.post(name: Plane.NotificationNames.didChangeRectangleAlpha, object: self, userInfo: [Plane.UserIDKeys.changedRectangle: specifiedRectangle])
+        NotificationCenter.default.post(name: Plane.NotificationNames.didChangeRectangleAlpha, object: self, userInfo: [Plane.UserInfoKeys.changedRectangle: specifiedRectangle])
         return .success(specifiedRectangle)
     }
 

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -34,17 +34,14 @@ class Plane {
     }
     
     public func specifyRectangle(point: Point) -> Result<AnyRectangularable, PlaneError> {
-        for rectangle in rectangles.reversed() {
-            if rectangle.isPointInArea(point) {
-                self.specifiedRectangle = rectangle
-                NotificationCenter.default.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self, userInfo: [Plane.UserInfoKeys.specifiedRectangle: rectangle])
-                return .success(rectangle)
-            }
+        guard let specifiedRectangle = findRectangle(above: point)  else {
+            self.specifiedRectangle = nil
+            NotificationCenter.default.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self)
+            return .failure(.cannotSpecifyRectangleError)
         }
-        self.specifiedRectangle = nil
-        NotificationCenter.default.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self)
-        return .failure(.cannotSpecifyRectangleError)
-        
+        self.specifiedRectangle = specifiedRectangle
+        NotificationCenter.default.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self, userInfo: [Plane.UserInfoKeys.specifiedRectangle: specifiedRectangle])
+        return .success(specifiedRectangle)
     }
     
     public func addNewRectangle(in frame: (width: Double, height: Double)) {
@@ -79,6 +76,15 @@ class Plane {
         specifiedRectangle.changeAlphaValue(to: newAlpha)
         NotificationCenter.default.post(name: Plane.NotificationNames.didChangeRectangleAlpha, object: self, userInfo: [Plane.UserInfoKeys.changedRectangle: specifiedRectangle])
         return .success(specifiedRectangle)
+    }
+    
+    private func findRectangle(above point: Point) -> AnyRectangularable? {
+        for rectangle in rectangles.reversed() {
+            if rectangle.isPointInArea(point) {
+                return rectangle
+            }
+        }
+        return nil
     }
 
 }

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -8,16 +8,22 @@
 import Foundation
 
 class Plane {
+    struct NotificationNames {
+        static let didAddRectangle = Notification.Name("PlaneDidAddRectangle")
+        static let didSpecifyRectangle = Notification.Name("PlaneDidSpecifyRectangle")
+        static let didChangeRectangleBackgroundColor = Notification.Name("PlaneDidChangeRectangleBackgroundColor")
+        static let didChangeRectangleAlpha = Notification.Name("PlaneDidChangeRectangleAlpha")
+    }
+    
+    struct UserIDKeys {
+        static let changedRectangle = "changedRectangle"
+        static let specifiedRectangle = "specifiedRectangle"
+        static let addedRectangle = "addedRectangle"
+    }
+    
     private var rectangles = [Rectangularable]()
     private var specifiedRectangle: Rectangularable?
     private let notificationCenter = NotificationCenter.default
-    static let didAddRectangle = Notification.Name("PlaneDidAddRectangle")
-    static let didSpecifyRectangle = Notification.Name("PlaneDidSpecifyRectangle")
-    static let didChangeRectangleBackgroundColor = Notification.Name("PlaneDidChangeRectangleBackgroundColor")
-    static let didChangeRectangleAlpha = Notification.Name("PlaneDidChangeRectangleAlpha")
-    static let changedRectangle = "ChangedRectangle"
-    static let specifiedRectangle = "specifiedRectangle"
-    static let addedRectangle = "addedRectanlge"
     var count: Int {
         return rectangles.count
     }
@@ -34,19 +40,19 @@ class Plane {
     public func specifyRectangle(point: Point) -> Result<Rectangularable, PlaneError> {
         guard let specifiedRectangle = self[point] else {
             self.specifiedRectangle = nil
-            notificationCenter.post(name: Plane.didSpecifyRectangle, object: self)
+            notificationCenter.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self)
             return .failure(.cannotSpecifyRectangleError)
         }
         
         self.specifiedRectangle = specifiedRectangle
-        notificationCenter.post(name: Plane.didSpecifyRectangle, object: self, userInfo: [Plane.specifiedRectangle: specifiedRectangle])
+        notificationCenter.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self, userInfo: [Plane.UserIDKeys.specifiedRectangle: specifiedRectangle])
         return .success(specifiedRectangle)
     }
     
     public func addNewRectangle(in frame: (width: Double, height: Double)) {
         let newRectangle = RectangleFactory.makeRandomRectangle(in: frame)
         rectangles.append(newRectangle)
-        notificationCenter.post(name: Plane.didAddRectangle, object: self, userInfo: [Plane.addedRectangle: newRectangle])
+        notificationCenter.post(name: Plane.NotificationNames.didAddRectangle, object: self, userInfo: [Plane.UserIDKeys.addedRectangle: newRectangle])
     }
     
     public func changeBackgroundColor(to newColor: BackgroundColor) -> Result<Rectangularable, PlaneError> {
@@ -54,7 +60,7 @@ class Plane {
             return .failure(.noSpecifiedRectangleToChangeError)
         }
         specifiedRectangle.changeBackgroundColor(to: newColor)
-        notificationCenter.post(name: Plane.didChangeRectangleBackgroundColor, object: self, userInfo: [Plane.changedRectangle: specifiedRectangle])
+        notificationCenter.post(name: Plane.NotificationNames.didChangeRectangleBackgroundColor, object: self, userInfo: [Plane.UserIDKeys.changedRectangle: specifiedRectangle])
         return .success(specifiedRectangle)
     }
 
@@ -63,7 +69,7 @@ class Plane {
             return .failure(.noSpecifiedRectangleToChangeError)
         }
         specifiedRectangle.changeAlphaValue(to: newAlpha)
-        notificationCenter.post(name: Plane.didChangeRectangleAlpha, object: self, userInfo: [Plane.changedRectangle: specifiedRectangle])
+        notificationCenter.post(name: Plane.NotificationNames.didChangeRectangleAlpha, object: self, userInfo: [Plane.UserIDKeys.changedRectangle: specifiedRectangle])
         return .success(specifiedRectangle)
     }
 

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -23,7 +23,6 @@ class Plane {
     
     private var rectangles = [Rectangularable]()
     private var specifiedRectangle: Rectangularable?
-    private let notificationCenter = NotificationCenter.default
     var count: Int {
         return rectangles.count
     }
@@ -36,12 +35,12 @@ class Plane {
         for rectangle in rectangles.reversed() {
             if rectangle.isPointInArea(point) {
                 self.specifiedRectangle = rectangle
-                notificationCenter.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self, userInfo: [Plane.UserIDKeys.specifiedRectangle: rectangle])
+                NotificationCenter.default.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self, userInfo: [Plane.UserIDKeys.specifiedRectangle: rectangle])
                 return .success(rectangle)
             }
         }
         self.specifiedRectangle = nil
-        notificationCenter.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self)
+        NotificationCenter.default.post(name: Plane.NotificationNames.didSpecifyRectangle, object: self)
         return .failure(.cannotSpecifyRectangleError)
         
     }
@@ -49,7 +48,7 @@ class Plane {
     public func addNewRectangle(in frame: (width: Double, height: Double)) {
         let newRectangle = RectangleFactory.makeRandomRectangle(in: frame)
         rectangles.append(newRectangle)
-        notificationCenter.post(name: Plane.NotificationNames.didAddRectangle, object: self, userInfo: [Plane.UserIDKeys.addedRectangle: newRectangle])
+        NotificationCenter.default.post(name: Plane.NotificationNames.didAddRectangle, object: self, userInfo: [Plane.UserIDKeys.addedRectangle: newRectangle])
     }
     
     public func changeBackgroundColor(to newColor: BackgroundColor) -> Result<Rectangularable, PlaneError> {
@@ -57,7 +56,7 @@ class Plane {
             return .failure(.noSpecifiedRectangleToChangeError)
         }
         specifiedRectangle.changeBackgroundColor(to: newColor)
-        notificationCenter.post(name: Plane.NotificationNames.didChangeRectangleBackgroundColor, object: self, userInfo: [Plane.UserIDKeys.changedRectangle: specifiedRectangle])
+        NotificationCenter.default.post(name: Plane.NotificationNames.didChangeRectangleBackgroundColor, object: self, userInfo: [Plane.UserIDKeys.changedRectangle: specifiedRectangle])
         return .success(specifiedRectangle)
     }
 
@@ -66,7 +65,7 @@ class Plane {
             return .failure(.noSpecifiedRectangleToChangeError)
         }
         specifiedRectangle.changeAlphaValue(to: newAlpha)
-        notificationCenter.post(name: Plane.NotificationNames.didChangeRectangleAlpha, object: self, userInfo: [Plane.UserIDKeys.changedRectangle: specifiedRectangle])
+        NotificationCenter.default.post(name: Plane.NotificationNames.didChangeRectangleAlpha, object: self, userInfo: [Plane.UserIDKeys.changedRectangle: specifiedRectangle])
         return .success(specifiedRectangle)
     }
 

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -23,17 +23,17 @@ class Plane {
         static let addedPhoto = "addedPhoto"
     }
     
-    private var rectangles = [Rectangularable]()
-    private var specifiedRectangle: Rectangularable?
+    private var rectangles = [AnyRectangularable]()
+    private var specifiedRectangle: AnyRectangularable?
     var count: Int {
         return rectangles.count
     }
     
-    subscript(_ index: Int) -> Rectangularable? {
+    subscript(_ index: Int) -> AnyRectangularable? {
         return rectangles[index]
     }
     
-    public func specifyRectangle(point: Point) -> Result<Rectangularable, PlaneError> {
+    public func specifyRectangle(point: Point) -> Result<AnyRectangularable, PlaneError> {
         for rectangle in rectangles.reversed() {
             if rectangle.isPointInArea(point) {
                 self.specifiedRectangle = rectangle
@@ -59,16 +59,20 @@ class Plane {
         NotificationCenter.default.post(name: Plane.NotificationNames.didAddPhoto, object: self, userInfo: [Plane.UserInfoKeys.addedPhoto: newPhoto])
     }
     
-    public func changeBackgroundColor(to newColor: BackgroundColor) -> Result<Rectangularable, PlaneError> {
+    public func changeBackgroundColor(to newColor: BackgroundColor) -> Result<AnyRectangularable, PlaneError> {
         guard let specifiedRectangle = self.specifiedRectangle else {
             return .failure(.noSpecifiedRectangleToChangeError)
         }
-        specifiedRectangle.changeBackgroundColor(to: newColor)
-        NotificationCenter.default.post(name: Plane.NotificationNames.didChangeRectangleBackgroundColor, object: self, userInfo: [Plane.UserInfoKeys.changedRectangle: specifiedRectangle])
+        
+        if let specifiedRectangle = specifiedRectangle as? BackgroundColorChangable {
+            specifiedRectangle.changeBackgroundColor(to: newColor)
+            NotificationCenter.default.post(name: Plane.NotificationNames.didChangeRectangleBackgroundColor, object: self, userInfo: [Plane.UserInfoKeys.changedRectangle: specifiedRectangle])
+        }
+       
         return .success(specifiedRectangle)
     }
 
-    public func changeAlphaValue(to newAlpha: Alpha) -> Result<Rectangularable, PlaneError> {
+    public func changeAlphaValue(to newAlpha: Alpha) -> Result<AnyRectangularable, PlaneError> {
         guard let specifiedRectangle = self.specifiedRectangle else {
             return .failure(.noSpecifiedRectangleToChangeError)
         }

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 protocol Rectangularable {
+    var size: Size {get}
+    var backgroundColor: BackgroundColor {get}
+    var alpha: Alpha {get}
     func isPointInArea(_ point: Point) -> Bool
     func changeBackgroundColor(to newColor: BackgroundColor)
     func changeAlphaValue(to newAlpha: Alpha)

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -14,6 +14,7 @@ protocol Rectangularable {
     func isPointInArea(_ point: Point) -> Bool
     func changeBackgroundColor(to newColor: BackgroundColor)
     func changeAlphaValue(to newAlpha: Alpha)
+    func backgroundColorButtonShouldBecomeHidden() -> Bool
 }
 
 class Rectangle: Rectangularable {
@@ -50,6 +51,10 @@ class Rectangle: Rectangularable {
     
     func changeAlphaValue(to newAlpha: Alpha) {
         self.alpha = newAlpha
+    }
+    
+    func backgroundColorButtonShouldBecomeHidden() -> Bool {
+        return false
     }
 
 }

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -7,72 +7,22 @@
 
 import Foundation
 
-protocol Rectangularable {
-    var size: Size {get}
+protocol BackgroundColorChangable {
     var backgroundColor: BackgroundColor {get}
-    var alpha: Alpha {get}
-    func isPointInArea(_ point: Point) -> Bool
+    
     func changeBackgroundColor(to newColor: BackgroundColor)
-    func changeAlphaValue(to newAlpha: Alpha)
-    func backgroundColorButtonShouldBecomeHidden() -> Bool
 }
 
-class Rectangle: Rectangularable {
-    private let id: ID
-    private(set) var size: Size
-    private(set) var point: Point
+class Rectangle: AnyRectangularable, BackgroundColorChangable {
     private(set) var backgroundColor: BackgroundColor
-    private(set) var alpha: Alpha
     
-    init(id: ID, width: Double, height: Double, x: Double, y: Double, backgroundColor: BackgroundColor, alpha: Alpha) {
-        self.id = id
-        size = Size(width: width, height: height)
-        point = Point(x: x, y: y)
+    init(size: Size, point: Point, backgroundColor: BackgroundColor, alpha: Alpha) {
         self.backgroundColor = backgroundColor
-        self.alpha = alpha
-    }
-    
-    init(id: ID, size: Size, point: Point, backgroundColor: BackgroundColor, alpha: Alpha) {
-        self.id = id
-        self.size = size
-        self.point = point
-        self.backgroundColor = backgroundColor
-        self.alpha = alpha
-    }
-    
-    func isPointInArea(_ point: Point) -> Bool {
-        return point.x >= self.point.x && point.x <= self.point.x + self.size.width &&
-            point.y >= self.point.y && point.y <= self.point.y + self.size.height
+        super.init(size: size, point: point, alpha: alpha)
     }
     
     func changeBackgroundColor(to newColor: BackgroundColor) {
         self.backgroundColor = newColor
     }
-    
-    func changeAlphaValue(to newAlpha: Alpha) {
-        self.alpha = newAlpha
-    }
-    
-    func backgroundColorButtonShouldBecomeHidden() -> Bool {
-        return false
-    }
 
-}
-
-extension Rectangle: CustomStringConvertible {
-    var description: String {
-        return "\(id) Rectangle, \(point), \(size), \(backgroundColor), \(alpha)"
-    }
-}
-
-extension Rectangle: Equatable {
-    static func == (lhs: Rectangle, rhs: Rectangle) -> Bool {
-        return lhs.id == rhs.id
-    }
-}
-
-extension Rectangle: Hashable {
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
 }

--- a/DrawingApp/DrawingApp/Model/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Model/RectangleFactory.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 class RectangleFactory {
     
@@ -18,6 +19,16 @@ class RectangleFactory {
         
         let newRectangle = Rectangle(id: id, size: size, point: point, backgroundColor: backgroundColor, alpha: alpha)
         return newRectangle
+    }
+    
+    public static func makePhoto(in frame: (width: Double, height: Double), image: UIImage) -> Rectangularable {
+        let size = Size(width: 150, height: 120)
+        let point = Point.random(in: frame)
+        let alpha = Alpha.random()
+        let id = ID()
+        
+        let newPhoto = Photo(id: id, size: size, point: point, image: image, alpha: alpha)
+        return newPhoto
     }
     
 }

--- a/DrawingApp/DrawingApp/Model/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Model/RectangleFactory.swift
@@ -9,24 +9,22 @@ import Foundation
 
 class RectangleFactory {
     
-    public static func makeRandomRectangle(in frame: (width: Double, height: Double)) -> Rectangularable {
+    public static func makeRandomRectangle(in frame: (width: Double, height: Double)) -> AnyRectangularable {
         let size = Size(width: 150, height: 120)
         let point = Point.random(in: frame)
         let backgroundColor = BackgroundColor.random()
         let alpha = Alpha.random()
-        let id = ID()
         
-        let newRectangle = Rectangle(id: id, size: size, point: point, backgroundColor: backgroundColor, alpha: alpha)
+        let newRectangle = Rectangle(size: size, point: point, backgroundColor: backgroundColor, alpha: alpha)
         return newRectangle
     }
     
-    public static func makePhoto(in frame: (width: Double, height: Double), image: Data) -> Rectangularable {
+    public static func makePhoto(in frame: (width: Double, height: Double), image: Data) -> AnyRectangularable {
         let size = Size(width: 150, height: 120)
         let point = Point.random(in: frame)
         let alpha = Alpha.random()
-        let id = ID()
         
-        let newPhoto = Photo(id: id, size: size, point: point, image: image, alpha: alpha)
+        let newPhoto = Photo(size: size, point: point, image: image, alpha: alpha)
         return newPhoto
     }
     

--- a/DrawingApp/DrawingApp/Model/RectangleFactory.swift
+++ b/DrawingApp/DrawingApp/Model/RectangleFactory.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import UIKit
 
 class RectangleFactory {
     
@@ -21,7 +20,7 @@ class RectangleFactory {
         return newRectangle
     }
     
-    public static func makePhoto(in frame: (width: Double, height: Double), image: UIImage) -> Rectangularable {
+    public static func makePhoto(in frame: (width: Double, height: Double), image: Data) -> Rectangularable {
         let size = Size(width: 150, height: 120)
         let point = Point.random(in: frame)
         let alpha = Alpha.random()

--- a/DrawingApp/DrawingApp/Model/ViewFactory.swift
+++ b/DrawingApp/DrawingApp/Model/ViewFactory.swift
@@ -21,6 +21,19 @@ class ViewFactory {
         
         return newView
     }
+    
+    static func makePhotoView(of photo: Photo) -> RectangleViewable & UIView {
+        let point = photo.point
+        let size = photo.size
+        let frame = CGRect(x: point.x, y: point.y, width: size.width, height: size.height)
+        let alpha = CGFloat(photo.alpha.value)
+        let image = photo.image
+        
+        let newView = PhotoView(frame: frame, alpha: alpha, image: UIImage(data: image) ?? UIImage())
+        
+        return newView
+    }
+    
 }
 
 extension BackgroundColor {

--- a/DrawingApp/DrawingApp/Model/ViewFactory.swift
+++ b/DrawingApp/DrawingApp/Model/ViewFactory.swift
@@ -30,6 +30,8 @@ class ViewFactory {
         let image = photo.image
         
         let newView = PhotoView(frame: frame, alpha: alpha, image: UIImage(data: image) ?? UIImage())
+        newView.clipsToBounds = true
+        newView.contentMode = .scaleAspectFill
         
         return newView
     }

--- a/DrawingApp/DrawingApp/Model/ViewFactory.swift
+++ b/DrawingApp/DrawingApp/Model/ViewFactory.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 class ViewFactory {
-    static func makeRectangleView(of rectangle: Rectangle) -> RectangleViewable & UIView {
+    static func makeRectangleView(of rectangle: AnyRectangularable & BackgroundColorChangable) -> UIView & RectangleViewable {
         let point = rectangle.point
         let size = rectangle.size
         let frame = CGRect(x: point.x, y: point.y, width: size.width, height: size.height)
@@ -22,7 +22,7 @@ class ViewFactory {
         return newView
     }
     
-    static func makePhotoView(of photo: Photo) -> RectangleViewable & UIView {
+    static func makePhotoView(of photo: AnyRectangularable & imageDataHavable) -> UIView & RectangleViewable {
         let point = photo.point
         let size = photo.size
         let frame = CGRect(x: point.x, y: point.y, width: size.width, height: size.height)

--- a/DrawingApp/DrawingApp/Model/ViewFactory.swift
+++ b/DrawingApp/DrawingApp/Model/ViewFactory.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 class ViewFactory {
-    static func makeRectangleView(of rectangle: Rectangle) -> RectangleViewable {
+    static func makeRectangleView(of rectangle: Rectangle) -> RectangleViewable & UIView {
         let point = rectangle.point
         let size = rectangle.size
         let frame = CGRect(x: point.x, y: point.y, width: size.width, height: size.height)

--- a/DrawingApp/DrawingApp/View/PhotoView.swift
+++ b/DrawingApp/DrawingApp/View/PhotoView.swift
@@ -1,0 +1,37 @@
+//
+//  PhotoView.swift
+//  DrawingApp
+//
+//  Created by 김한솔 on 2022/03/14.
+//
+
+import UIKit
+
+class PhotoView: UIImageView, RectangleViewable {
+    
+    init(frame: CGRect, alpha: CGFloat, image: UIImage) {
+        super.init(frame: frame)
+        self.alpha = alpha
+        self.image = image
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.alpha = 1.0
+        self.image = UIImage()
+    }
+    
+    required override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.alpha = 1.0
+        self.image = UIImage()
+    }
+    
+    func changeBackgroundColor(to newColor: UIColor) {
+        self.backgroundColor = newColor
+    }
+    
+    func changeAlphaValue(to newAlphaValue: CGFloat) {
+        self.alpha = newAlphaValue
+    }
+}

--- a/DrawingApp/DrawingApp/View/RectangleView.swift
+++ b/DrawingApp/DrawingApp/View/RectangleView.swift
@@ -8,6 +8,10 @@
 import UIKit
 
 protocol RectangleViewable {
+    var frame: CGRect {get set}
+    var alpha: CGFloat {get set}
+    var backgroundColor: UIColor? {get set}
+    var layer: CALayer {get}
     func changeBackgroundColor(to newColor: UIColor)
     func changeAlphaValue(to newAlphaValue: CGFloat)
 }

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -12,7 +12,6 @@ class ViewController: UIViewController {
     
     private var plane = Plane()
     private var rectangleAndViewMap = [AnyHashable: RectangleViewable]()
-    private let notificationCenter = NotificationCenter.default
     private var selectedView: RectangleView?
     weak var generateRectangleButton: UIButton!
     weak var drawableAreaView: UIView!
@@ -124,10 +123,10 @@ class ViewController: UIViewController {
     }
     
     func setNotificationCenter() {
-        notificationCenter.addObserver(self, selector: #selector(planeDidAddRectangle(_:)), name: Plane.NotificationNames.didAddRectangle, object: plane)
-        notificationCenter.addObserver(self, selector: #selector(planeDidSpecifyRectangle(_:)), name: Plane.NotificationNames.didSpecifyRectangle, object: plane)
-        notificationCenter.addObserver(self, selector: #selector(planeDidChangeRectangleBackgroundColor(_:)), name: Plane.NotificationNames.didChangeRectangleBackgroundColor, object: plane)
-        notificationCenter.addObserver(self, selector: #selector(planeDidChangeRectangleAlpha(_:)), name: Plane.NotificationNames.didChangeRectangleAlpha, object: plane)
+        NotificationCenter.default.addObserver(self, selector: #selector(planeDidAddRectangle(_:)), name: Plane.NotificationNames.didAddRectangle, object: plane)
+        NotificationCenter.default.addObserver(self, selector: #selector(planeDidSpecifyRectangle(_:)), name: Plane.NotificationNames.didSpecifyRectangle, object: plane)
+        NotificationCenter.default.addObserver(self, selector: #selector(planeDidChangeRectangleBackgroundColor(_:)), name: Plane.NotificationNames.didChangeRectangleBackgroundColor, object: plane)
+        NotificationCenter.default.addObserver(self, selector: #selector(planeDidChangeRectangleAlpha(_:)), name: Plane.NotificationNames.didChangeRectangleAlpha, object: plane)
     }
 }
 

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -190,13 +190,10 @@ extension ViewController {
               }
         
         updateSelectedView(matchedView)
-        updateBackgroundButton(color: specifiedRectangle.backgroundColor, alpha: specifiedRectangle.alpha)
+        updateBackgroundColorButton(with: specifiedRectangle)
         updateAlphaSlider(alpha: Float(matchedView.alpha))
         updateMinusAlphaValueButton(with: Float(matchedView.alpha))
         updatePlusAlphaValueButton(with: Float(matchedView.alpha))
-        if let specifiedPhoto = specifiedRectangle as? Photo {
-            self.backgroundColorButton.isHidden = true
-        }
     }
     
     @objc func planeDidChangeRectangleBackgroundColor(_ notification: Notification) {
@@ -208,7 +205,7 @@ extension ViewController {
         let newBackgroundColor = backgroundColorChangedRectangle.backgroundColor
         matchedView.changeBackgroundColor(to: newBackgroundColor.convertToUIColor())
         let previousAlpha = backgroundColorChangedRectangle.alpha
-        updateBackgroundButton(color: newBackgroundColor, alpha: previousAlpha)
+        updateBackgroundColorButton(with: backgroundColorChangedRectangle)
     }
     
     @objc func planeDidChangeRectangleAlpha(_ notification: Notification) {
@@ -230,11 +227,11 @@ extension ViewController {
         selectedView.layer.borderColor = UIColor.black.cgColor
     }
     
-    private func updateBackgroundButton(color: BackgroundColor, alpha: Alpha) {
+    private func updateBackgroundColorButton(with rectangle: Rectangularable) {
         backgroundColorButton.isEnabled = true
-        backgroundColorButton.isHidden = false
-        backgroundColorButton.setTitle(color.hexCode, for: .normal)
-        let buttonBackgroundColor = color.convertToUIColor(with: alpha.value)
+        backgroundColorButton.isHidden = rectangle.backgroundColorButtonShouldBecomeHidden()
+        backgroundColorButton.setTitle(rectangle.backgroundColor.hexCode, for: .normal)
+        let buttonBackgroundColor = rectangle.backgroundColor.convertToUIColor(with: rectangle.alpha.value)
         backgroundColorButton.backgroundColor = buttonBackgroundColor
     }
     

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -136,7 +136,7 @@ extension ViewController {
         guard let addedRectangle = notification.userInfo?[Plane.UserIDKeys.addedRectangle] as? Rectangle else {return}
         os_log("\(addedRectangle)")
         
-        guard let newRectangleView = ViewFactory.makeRectangleView(of: addedRectangle) as? RectangleView else {return}
+        let newRectangleView = ViewFactory.makeRectangleView(of: addedRectangle)
         self.drawableAreaView.addSubview(newRectangleView)
         rectangleAndViewMap[addedRectangle] = newRectangleView
     }

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -183,7 +183,7 @@ extension ViewController {
     }
     
     @objc func planeDidSpecifyRectangle(_ notification: Notification) {
-        guard let specifiedRectangle = notification.userInfo?[Plane.UserInfoKeys.specifiedRectangle] as? Rectangle,
+        guard let specifiedRectangle = notification.userInfo?[Plane.UserInfoKeys.specifiedRectangle] as? AnyRectangularable,
               let matchedView = rectangleAndViewMap[specifiedRectangle] else {
                   initializeViewsInTouchedEmptySpaceCondition()
                   return
@@ -197,19 +197,20 @@ extension ViewController {
     }
     
     @objc func planeDidChangeRectangleBackgroundColor(_ notification: Notification) {
-        guard let backgroundColorChangedRectangle = notification.userInfo?[Plane.UserInfoKeys.changedRectangle] as? Rectangle,
+        guard let backgroundColorChangedRectangle = notification.userInfo?[Plane.UserInfoKeys.changedRectangle] as? AnyRectangularable,
               let matchedView = rectangleAndViewMap[backgroundColorChangedRectangle] else {
                   return
               }
-        
-        let newBackgroundColor = backgroundColorChangedRectangle.backgroundColor
-        matchedView.changeBackgroundColor(to: newBackgroundColor.convertToUIColor())
+        if let backgroundColorChangedRectangle = backgroundColorChangedRectangle as? BackgroundColorChangable {
+            let newBackgroundColor = backgroundColorChangedRectangle.backgroundColor
+            matchedView.changeBackgroundColor(to: newBackgroundColor.convertToUIColor())
+        }
         let previousAlpha = backgroundColorChangedRectangle.alpha
         updateBackgroundColorButton(with: backgroundColorChangedRectangle)
     }
     
     @objc func planeDidChangeRectangleAlpha(_ notification: Notification) {
-        guard let alphaChangedRectangle = notification.userInfo?[Plane.UserInfoKeys.changedRectangle] as? Rectangle,
+        guard let alphaChangedRectangle = notification.userInfo?[Plane.UserInfoKeys.changedRectangle] as? AnyRectangularable,
               let matchedView = rectangleAndViewMap[alphaChangedRectangle] else {
                   return
               }
@@ -227,11 +228,14 @@ extension ViewController {
         selectedView.layer.borderColor = UIColor.black.cgColor
     }
     
-    private func updateBackgroundColorButton(with rectangle: Rectangularable) {
+    private func updateBackgroundColorButton(with rectangle: AnyRectangularable) {
+        backgroundColorButton.isHidden = rectangle.backgroundColorButtonShouldBecomeHidden
+        let currentAlphaValue = rectangle.alpha.value
+        
+        guard let rectangle = rectangle as? BackgroundColorChangable else {return}
         backgroundColorButton.isEnabled = true
-        backgroundColorButton.isHidden = rectangle.backgroundColorButtonShouldBecomeHidden()
         backgroundColorButton.setTitle(rectangle.backgroundColor.hexCode, for: .normal)
-        let buttonBackgroundColor = rectangle.backgroundColor.convertToUIColor(with: rectangle.alpha.value)
+        let buttonBackgroundColor = rectangle.backgroundColor.convertToUIColor(with: currentAlphaValue)
         backgroundColorButton.backgroundColor = buttonBackgroundColor
     }
     

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -124,17 +124,17 @@ class ViewController: UIViewController {
     }
     
     func setNotificationCenter() {
-        notificationCenter.addObserver(self, selector: #selector(planeDidAddRectangle(_:)), name: Plane.didAddRectangle, object: plane)
-        notificationCenter.addObserver(self, selector: #selector(planeDidSpecifyRectangle(_:)), name: Plane.didSpecifyRectangle, object: plane)
-        notificationCenter.addObserver(self, selector: #selector(planeDidChangeRectangleBackgroundColor(_:)), name: Plane.didChangeRectangleBackgroundColor, object: plane)
-        notificationCenter.addObserver(self, selector: #selector(planeDidChangeRectangleAlpha(_:)), name: Plane.didChangeRectangleAlpha, object: plane)
+        notificationCenter.addObserver(self, selector: #selector(planeDidAddRectangle(_:)), name: Plane.NotificationNames.didAddRectangle, object: plane)
+        notificationCenter.addObserver(self, selector: #selector(planeDidSpecifyRectangle(_:)), name: Plane.NotificationNames.didSpecifyRectangle, object: plane)
+        notificationCenter.addObserver(self, selector: #selector(planeDidChangeRectangleBackgroundColor(_:)), name: Plane.NotificationNames.didChangeRectangleBackgroundColor, object: plane)
+        notificationCenter.addObserver(self, selector: #selector(planeDidChangeRectangleAlpha(_:)), name: Plane.NotificationNames.didChangeRectangleAlpha, object: plane)
     }
 }
 
 extension ViewController {
     
     @objc func planeDidAddRectangle(_ notification: Notification) {
-        guard let addedRectangle = notification.userInfo?[Plane.addedRectangle] as? Rectangle else {return}
+        guard let addedRectangle = notification.userInfo?[Plane.UserIDKeys.addedRectangle] as? Rectangle else {return}
         os_log("\(addedRectangle)")
         
         guard let newRectangleView = ViewFactory.makeRectangleView(of: addedRectangle) as? RectangleView else {return}
@@ -143,7 +143,7 @@ extension ViewController {
     }
     
     @objc func planeDidSpecifyRectangle(_ notification: Notification) {
-        guard let specifiedRectangle = notification.userInfo?[Plane.specifiedRectangle] as? Rectangle,
+        guard let specifiedRectangle = notification.userInfo?[Plane.UserIDKeys.specifiedRectangle] as? Rectangle,
               let matchedView = rectangleAndViewMap[specifiedRectangle],
               let matchedView = matchedView as? RectangleView else {
                   initializeViewsInTouchedEmptySpaceCondition()
@@ -158,7 +158,7 @@ extension ViewController {
     }
     
     @objc func planeDidChangeRectangleBackgroundColor(_ notification: Notification) {
-        guard let backgroundColorChangedRectangle = notification.userInfo?[Plane.changedRectangle] as? Rectangle,
+        guard let backgroundColorChangedRectangle = notification.userInfo?[Plane.UserIDKeys.changedRectangle] as? Rectangle,
               let matchedView = rectangleAndViewMap[backgroundColorChangedRectangle] else {
                   return
               }
@@ -170,7 +170,7 @@ extension ViewController {
     }
     
     @objc func planeDidChangeRectangleAlpha(_ notification: Notification) {
-        guard let alphaChangedRectangle = notification.userInfo?[Plane.changedRectangle] as? Rectangle,
+        guard let alphaChangedRectangle = notification.userInfo?[Plane.UserIDKeys.changedRectangle] as? Rectangle,
               let matchedView = rectangleAndViewMap[alphaChangedRectangle] else {
                   return
               }

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -143,8 +143,7 @@ extension ViewController {
     
     @objc func planeDidSpecifyRectangle(_ notification: Notification) {
         guard let specifiedRectangle = notification.userInfo?[Plane.UserIDKeys.specifiedRectangle] as? Rectangle,
-              let matchedView = rectangleAndViewMap[specifiedRectangle],
-              let matchedView = matchedView as? RectangleView else {
+              let matchedView = rectangleAndViewMap[specifiedRectangle] else {
                   initializeViewsInTouchedEmptySpaceCondition()
                   return
               }

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -194,6 +194,9 @@ extension ViewController {
         updateAlphaSlider(alpha: Float(matchedView.alpha))
         updateMinusAlphaValueButton(with: Float(matchedView.alpha))
         updatePlusAlphaValueButton(with: Float(matchedView.alpha))
+        if let specifiedPhoto = specifiedRectangle as? Photo {
+            self.backgroundColorButton.isHidden = true
+        }
     }
     
     @objc func planeDidChangeRectangleBackgroundColor(_ notification: Notification) {
@@ -229,6 +232,7 @@ extension ViewController {
     
     private func updateBackgroundButton(color: BackgroundColor, alpha: Alpha) {
         backgroundColorButton.isEnabled = true
+        backgroundColorButton.isHidden = false
         backgroundColorButton.setTitle(color.hexCode, for: .normal)
         let buttonBackgroundColor = color.convertToUIColor(with: alpha.value)
         backgroundColorButton.backgroundColor = buttonBackgroundColor

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -14,6 +14,7 @@ class ViewController: UIViewController {
     private var rectangleAndViewMap = [AnyHashable: RectangleViewable]()
     private var selectedView: RectangleViewable?
     weak var generateRectangleButton: UIButton!
+    weak var generateImageRectangleButton: UIButton!
     weak var drawableAreaView: UIView!
     @IBOutlet weak var statusView: UIView!
     @IBOutlet weak var backgroundColorButton: UIButton!
@@ -28,8 +29,9 @@ class ViewController: UIViewController {
         
         backgroundColorButton.setTitle("배경색 버튼", for: .disabled)
         
-        addGenerateRectangleButton()
         addDrawableAreaView()
+        addGenerateRectangleButton()
+        addGenerateImageRectangleButton()
         
         initializeViewsInTouchedEmptySpaceCondition()
         
@@ -44,11 +46,40 @@ class ViewController: UIViewController {
         let generateButton = UIButton(type: .custom, primaryAction: buttonUIAction)
         let buttonWidth = 100.0
         let buttonHeight = 100.0
-        let buttonX = (self.view.frame.size.width/2.0) - (buttonWidth/2.0)
+        let spacing = 0.5
+        let buttonX = (self.drawableAreaView.frame.size.width/2.0) - (buttonWidth + spacing)
         let buttonY = self.view.frame.size.height - buttonHeight
+        let buttonImageConfiguration = UIImage.SymbolConfiguration.init(hierarchicalColor: .black)
+        let buttonImage = UIImage(systemName: "rectangle", withConfiguration: buttonImageConfiguration)
         generateButton.frame = CGRect(x: buttonX, y: buttonY, width: buttonWidth, height: buttonHeight)
-        generateButton.backgroundColor = .gray
-        generateButton.setTitle("사각형 생성", for: .normal)
+        generateButton.backgroundColor = .systemGray6
+        generateButton.setImage(buttonImage, for: .normal)
+        generateButton.layer.cornerRadius = 15
+        
+        self.generateRectangleButton = generateButton
+        self.view.addSubview(generateButton)
+    }
+    
+    func addGenerateImageRectangleButton() {
+        let buttonUIAction = UIAction { _ in
+            let imagePicker = UIImagePickerController()
+            imagePicker.sourceType = .photoLibrary
+            imagePicker.allowsEditing = true
+            imagePicker.delegate = self
+            self.present(imagePicker, animated: true)
+        }
+        let generateButton = UIButton(type: .custom, primaryAction: buttonUIAction)
+        let buttonWidth = 100.0
+        let buttonHeight = 100.0
+        let spacing = 0.5
+        let buttonX = (self.drawableAreaView.frame.size.width/2.0) + spacing
+        let buttonY = self.view.frame.size.height - buttonHeight
+        let buttonImageConfiguration = UIImage.SymbolConfiguration.init(hierarchicalColor: .black)
+        let buttonImage = UIImage(systemName: "photo", withConfiguration: buttonImageConfiguration)
+        generateButton.frame = CGRect(x: buttonX, y: buttonY, width: buttonWidth, height: buttonHeight)
+        generateButton.backgroundColor = .systemGray6
+        generateButton.setImage(buttonImage, for: .normal)
+        generateButton.layer.cornerRadius = 15
         
         self.generateRectangleButton = generateButton
         self.view.addSubview(generateButton)

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -98,7 +98,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func alphaSliderValueChanged(_ sender: UISlider) {
-        let newAlphaValue = round(sender.value * 10) / 10
+        let newAlphaValue = sender.value.normalized()
         guard let convertedOpacityLevel = Alpha.OpacityLevel(rawValue: newAlphaValue) else {return}
         let newAlpha = Alpha(opacityLevel: convertedOpacityLevel)
         
@@ -109,7 +109,7 @@ class ViewController: UIViewController {
         guard let selectedView = self.selectedView else {return}
         let previousAlphaValue = Float(selectedView.alpha)
         let newAlphaValue = previousAlphaValue - 0.1
-        let normalizedNewAlphaValue = round(newAlphaValue * 10) / 10
+        let normalizedNewAlphaValue = newAlphaValue.normalized()
         guard let convertedOpacityLevel = Alpha.OpacityLevel(rawValue: normalizedNewAlphaValue) else {return}
         plane.changeAlphaValue(to: Alpha(opacityLevel: convertedOpacityLevel))
     }
@@ -117,7 +117,7 @@ class ViewController: UIViewController {
         guard let selectedView = self.selectedView else {return}
         let previousAlphaValue = Float(selectedView.alpha)
         let newAlphaValue = previousAlphaValue + 0.1
-        let normalizedNewAlphaValue = round(newAlphaValue * 10) / 10
+        let normalizedNewAlphaValue = newAlphaValue.normalized()
         guard let convertedOpacityLevel = Alpha.OpacityLevel(rawValue: normalizedNewAlphaValue) else {return}
         plane.changeAlphaValue(to: Alpha(opacityLevel: convertedOpacityLevel))
     }
@@ -207,7 +207,7 @@ extension ViewController {
     }
     
     private func updateMinusAlphaValueButton(with alpha: Float) {
-        if round(alpha * 10) / 10.0 > 0.1 {
+        if alpha.normalized() > 0.1 {
             minusAlphaValueButton.isEnabled = true
             minusAlphaValueButton.backgroundColor = .white
         } else {
@@ -217,7 +217,7 @@ extension ViewController {
     }
     
     private func updatePlusAlphaValueButton(with alpha: Float) {
-        if round(alpha * 10) / 10.0 < 1.0 {
+        if alpha.normalized() < 1.0 {
             plusAlphaValueButton.isEnabled = true
             plusAlphaValueButton.backgroundColor = .white
         } else {
@@ -239,5 +239,11 @@ extension BackgroundColor {
         let convertedBlue = Double(self.b) / 255.0
         
         return UIColor(red: convertedRed, green: convertedGreen, blue: convertedBlue, alpha: CGFloat(alphaValue))
+    }
+}
+
+extension Float {
+    fileprivate func normalized() -> Float {
+        return roundf(self * 10) / 10
     }
 }

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -12,7 +12,7 @@ class ViewController: UIViewController {
     
     private var plane = Plane()
     private var rectangleAndViewMap = [AnyHashable: RectangleViewable]()
-    private var selectedView: RectangleView?
+    private var selectedView: RectangleViewable?
     weak var generateRectangleButton: UIButton!
     weak var drawableAreaView: UIView!
     @IBOutlet weak var statusView: UIView!
@@ -179,7 +179,7 @@ extension ViewController {
         updateStatusViewElement(with: newAlphaValue)
     }
     
-    private func updateSelectedView(_ selectedView: RectangleView) {
+    private func updateSelectedView(_ selectedView: RectangleViewable) {
         self.selectedView?.layer.borderWidth = 0
         
         self.selectedView = selectedView

--- a/README.md
+++ b/README.md
@@ -81,11 +81,7 @@
 
 ## Step2. 속성 변경 동작 및 Unit Test
 
-
-
 ### 📌주요 작업 내용
-
-
 
 - [x] 사각형 뷰와 Rectangle 객체의 매칭을 위해, id 프로퍼티를 가지는 UIView를 RectangleView로 생성
 
@@ -152,3 +148,67 @@
 3. 빈공간을 터치하면 오른쪽의 버튼, 슬라이더가 비활성화됩니다.
 
 <img src="https://user-images.githubusercontent.com/92504186/157002715-f7827f7a-063d-4448-acf4-a16ce61eb832.gif" alt="SS 2022-03-07 PM 06 18 45" style="zoom:50%;" />
+
+---
+
+---
+
+
+
+## Step3. 관찰자(Observer) 패턴
+
+### :pushpin:주요 작업 내용
+
+- [x] ViewContoller에서, 뷰로 부터의 입력 이벤트를 처리하기 위해 NotificationCenter를 이용한 Observer 패턴 사용
+	- [x] 이전에 사용하던 Delegate 패턴은 모두 제거
+- [x] ViewController, Plane이 구체 타입이 아닌 추상 타입에 의존하도록 수정
+	- [x] RectangleView, Rectangle 객체에 대한 추상 타입으로 RectangleViewable, Rectangularable 프로토콜 선언
+	- [x] ViewFactory와 RectangleFactory가 추상 타입을 반환하도록 수정
+
+---
+
+### :computer:작업 진행과정
+
+1. ViewController에서 Plane객체의 변화에 대한 옵저버 설정 및 변화가 감지되면 실행될 메서드 선언
+
+	```swift
+	// class ViewController
+	NotificationCenter.default.addObserver(self, selector: #selector(planeDidAddRectangle(_:)), name: Plane.NotificationNames.didAddRectangle, object: plane)
+	
+	@objc func planeDidAddRectangle(_ notification: Notification) {
+	    // Plane이 Rectangle을 추가했을 때 ViewController에서 실행할 내용
+	}
+	```
+
+2. Plane에서 어떤 메서드가 호출되면 변화에 대한 내용을 post하도록 설정
+
+	```swift
+	// class Plane
+	public func addNewRectangle(in frame: (width: Double, height: Double)) {
+	    // ... Rectangle 추가하는 과정
+	    NotificationCenter.default.post(name: Plane.NotificationNames.didAddRectangle, object: self, userInfo: [Plane.UserIDKeys.addedRectangle: newRectangle])
+	}
+	```
+
+3. RectangleView가 채택하여, ViewController에서 참조할 추상 타입으로 RectangleViewable 프로토콜 선언
+
+4. Rectangle이 채택하여, ViewController와 Plane에서 참조할 추상 타입으로 Rectangularable 프로토콜 선언
+
+5. ViewFactory와 RectangleFactory가 추상 타입을 반환하도록 수정
+
+6. Plane, ViewController가 최대한 구체 타입에 의존하지 않도록 수정(수정이 더 필요함)
+
+
+
+> 완성 일시: 2022.03.14 10:40
+
+---
+
+### :clipboard:프로그램 동작 화면
+
+~~위의 Step2와 동일합니다~~
+
+---
+
+---
+


### PR DESCRIPTION
## 실행 화면
![SS 2022-03-14 PM 10 29 23](https://user-images.githubusercontent.com/92504186/158181980-bdb713b5-62e8-4fee-9475-b2eff491ce67.gif)
---
## 작업 목록
- [x] Refactoring
  - [x] namespace 활용하여 Plane 객체 내의 Constasnts 정리
  - [x] 팩토리 메서드의 반환 타입을 추상 타입으로 수정
  - [x] BackgroundColor의 입력값 범위를 제한하여 컴파일 단계에서 해당 범위가 맞는지 확인 가능하도록 수정
- [x] UIImagePicker를 이용해 사진을 추가하는 기능 구현
- [x] Photo, PhotoView 클래스 구현
- [x] VC에서 Photo 객체에 대한 입출력 흐름 추가
- [x] Photo를 터치하면 배경색 버튼이 비활성화되는 기능 추가
---
## 고민과 해결
1. 드디어 BackgroundColor 타입의 속성 값들의 제한을 설정할 방법을 생각해냈습니다. UInt8 타입을 이용하면, 0~255 범위 이외의 값들은 컴파일 단계에서 걸러진다는 것을 생각해내 BackgroundColor의 속성인 r,g,b를 모두 UInt8 타입으로 설정하고, BackgroundColor를 초기화 생성자의 매개변수도 모두 UInt8 타입으로 받도록 했습니다.
2. NotificationCenter를 통해 받아온 userInfo를 프로토콜인 추상 타입으로 타입 캐스팅을 하게 되면 Dictionary의 Key 값으로 이용할 수 없게 되어, 다른 방법을 찾다가 Photo를 Rectangle의 자식 클래스로 만들고, 어쩔 수 없이 userInfo를 구체 타입인 Rectangle로 타입 캐스팅하여 문제를 해결할 수 있었습니다. 해결된 것은 아니고 임시 방편을 찾은것 같다는 느낌을 받아, 해당 부분을 계속 고민해가며 수정할 예정입니다.
---
## 질문사항
- 아래의 부분에서 JK께서 프로토콜을 리턴받아놓고 as? RectangleView로 타입 캐스팅하는게 불편해보인다고 방법을 여쭤보셨었는데, 타입 캐스팅 과정 없이는 프로토콜을 리턴 받은 값으로 addSubview(_:)가 불가능했습니다. 해당 부분을 해결하기 위해, RectangleView를 생성해주는 팩토리 메서드의 반환 타입을 `UIView & RectangleViewable` 로 수정했습니다. 혹시 이런 경우에도 팩토리 메서드의 반환 타입이 구체 타입을 반환한다고 볼 수 있는건가요?
  - 수정전
  ```swift
  // class ViewFactory
  static func makeRectangleView(of rectangle: Rectangle) -> RectangleView {...}
  // class ViewController
  // @objc func planeDidAddRectangle(_:) {
   guard let newRectangleView = ViewFactory.makeRectangleView(of: addedRectangle) as? RectangleView else {return}
   self.drawableAreaView.addSubview(newRectangleView)
  ```
  - 수정후
  ```swift
  // class ViewFactory
  static func makeRectangleView(of rectangle: Rectangle) -> UIView & RectangleViewable {...}
  // class ViewController
  // @objc func planeDidAddRectangle(_:) {
  let newRectangleView = ViewFactory.makeRectangleView(of: addedRectangle)
  self.drawableAreaView.addSubview(newRectangleView)
  ```
- notificationCenter로 부터 userInfo를 받아오는 과정에서, 받아온 userInfo의 필요한 키의 Value를 `as? Rectangle` 로 변환해주다보니, 구체 타입에 의존한다는 리뷰를 받았는데, 이번 스텝을 진행하다보니 이 부분을 추상 타입으로 변환해주어야 Photo, Label 등을 일괄적으로 한 번에 처리할 수 있겠다는 생각을 했습니다. 
  이 부분에서 저는, 제가 선언한 Rectangularable 프로토콜을 채택하는 모델(예를 들어 RectModel로 이름을 설정하겠습니다.)을 선언하고, Photo, Label, Rectangle 객체가 RectModel을 상속받는 경우에는 이 문제를 해결할 수 있을 것 같은데,  `as? RectModel` 로 변환을 한다고 해서 이 부분에서 구체 타입에 의존하지 않지는 않기 때문에 말씀해주신 문제를 해결하는 방법은 아닌 것 같습니다. 그렇다고 프로토콜로 변환을 해주다보니, matchedView를 찾는 과정에서 [AnyHashable: RectangleViewable] 딕셔너리에 Key로 notificationCenter로부터 userInfo로 받아온 값을 사용해야 하는데, 추상 타입은 Hashable 할 수 없기 때문에 matchedView를 찾는 곳에서 문제가 생겼습니다.
  이런 경우에, 제가 말씀드린 RectView를 이용해 userInfo의 특정 Value를 변환하는 방법이 추상 타입에 의존한다고 볼 수 있을까요?
  리뷰 달아주셨던 코드는 아래의 코드입니다.
  ```swift
  @objc func planeDidSpecifyRectangle(_ notification: Notification) {
    guard let specifiedRectangle = notification.userInfo?[Plane.UserInfoKeys.specifiedRectangle] as? Rectangle,
          let matchedView = rectangleAndViewMap[specifiedRectangle] else {
              initializeViewsInTouchedEmptySpaceCondition()
              return
          }
  ...
  }
  ```