### PR TITLE
[Chez] Step2 - 배경색&투명도 조절, 구조개선

### DIFF
--- a/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
+++ b/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
@@ -15,25 +15,9 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="1180" height="820"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jy9-JN-6Qs" customClass="CanvasView" customModule="DrawingApp" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="975" height="820"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                            </view>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZHN-PQ-I2y" customClass="ControllerView" customModule="DrawingApp" customModuleProvider="target">
-                                <rect key="frame" x="983" y="0.0" width="197" height="820"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                            </view>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <connections>
-                        <outlet property="canvasView" destination="Jy9-JN-6Qs" id="Clp-FB-Ck3"/>
-                        <outlet property="controllerView" destination="ZHN-PQ-I2y" id="bPf-8q-15S"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/DrawingApp/DrawingApp/Convertor.swift
+++ b/DrawingApp/DrawingApp/Convertor.swift
@@ -24,16 +24,3 @@ struct Convertor {
     }
 
 }
-
-extension UIColor  {
-    
-    func convertHex() -> String {
-
-        let components = self.cgColor.components
-        let r: CGFloat = components?[0] ?? 0.0
-        let g: CGFloat = components?[1] ?? 0.0
-        let b: CGFloat = components?[2] ?? 0.0
-        let hexString = String.init(format: "#%02lX%02lX%02lX", lroundf(Float(r * 255)), lroundf(Float(g * 255)), lroundf(Float(b * 255)))
-        return hexString
-    }
-}

--- a/DrawingApp/DrawingApp/Convertor.swift
+++ b/DrawingApp/DrawingApp/Convertor.swift
@@ -18,4 +18,8 @@ struct Convertor {
         let B = CGFloat(color.blue) / 255
         return UIColor(red: R, green: G, blue: B, alpha: 1)
     }
+    
+    static func convertColor(from color: UIColor) -> Color {
+        return Color(R: Int(color.ciColor.red) * 255, G: Int(color.ciColor.green) * 255, B: Int(color.ciColor.blue) * 255)
+    }
 }

--- a/DrawingApp/DrawingApp/Convertor.swift
+++ b/DrawingApp/DrawingApp/Convertor.swift
@@ -18,8 +18,22 @@ struct Convertor {
         let B = CGFloat(color.blue) / 255
         return UIColor(red: R, green: G, blue: B, alpha: 1)
     }
+
+}
+
+extension UIColor  {
     
-    static func convertColor(from color: UIColor) -> Color {
-        return Color(R: Int(color.ciColor.red) * 255, G: Int(color.ciColor.green) * 255, B: Int(color.ciColor.blue) * 255)
+    func convertHex() -> String {
+
+        let components = self.cgColor.components
+        let r: CGFloat = components?[0] ?? 0.0
+        let g: CGFloat = components?[1] ?? 0.0
+        let b: CGFloat = components?[2] ?? 0.0
+
+        let hexString = String.init(format: "#%02lX%02lX%02lX", lroundf(Float(r * 255)), lroundf(Float(g * 255)), lroundf(Float(b * 255)))
+        return hexString
+
     }
+    
+    
 }

--- a/DrawingApp/DrawingApp/Convertor.swift
+++ b/DrawingApp/DrawingApp/Convertor.swift
@@ -10,12 +10,19 @@ import UIKit
 
 
 struct Convertor {
-    static func convertColor(from color: Color, alpha : CGFloat = 1.0) -> UIColor {
+    static func convertColor(from color: Color, alpha : Alpha) -> UIColor {
         let R = CGFloat(color.red) / 255
         let G = CGFloat(color.green) / 255
         let B = CGFloat(color.blue) / 255
-        return UIColor(red: R, green: G, blue: B, alpha: alpha)
+        let alphaValue = CGFloat(alpha.rawValue) * 0.1
+        return UIColor(red: R, green: G, blue: B, alpha: alphaValue)
     }
+    
+    static func colorToHexString(_ color: Color) -> String {
+        let hexString = String.init(format: "#%02lX%02lX%02lX", color.red, color.green, color.blue)
+        return hexString
+    }
+
 }
 
 extension UIColor  {

--- a/DrawingApp/DrawingApp/Convertor.swift
+++ b/DrawingApp/DrawingApp/Convertor.swift
@@ -10,15 +10,12 @@ import UIKit
 
 
 struct Convertor {
-    
-    
-    static func convertColor(from color: Color) -> UIColor {
+    static func convertColor(from color: Color, alpha : CGFloat = 1.0) -> UIColor {
         let R = CGFloat(color.red) / 255
         let G = CGFloat(color.green) / 255
         let B = CGFloat(color.blue) / 255
-        return UIColor(red: R, green: G, blue: B, alpha: 1)
+        return UIColor(red: R, green: G, blue: B, alpha: alpha)
     }
-
 }
 
 extension UIColor  {
@@ -29,11 +26,7 @@ extension UIColor  {
         let r: CGFloat = components?[0] ?? 0.0
         let g: CGFloat = components?[1] ?? 0.0
         let b: CGFloat = components?[2] ?? 0.0
-
         let hexString = String.init(format: "#%02lX%02lX%02lX", lroundf(Float(r * 255)), lroundf(Float(g * 255)), lroundf(Float(b * 255)))
         return hexString
-
     }
-    
-    
 }

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol PlaneDelegate {
     func RectangleDidAdd(_ rectangle: Rectangle)
-//    func changedBackgroundColor()
+    func BackgroundDidChanged()
 }
 
 
@@ -44,6 +44,8 @@ struct Plane{
     
     func changeBackgroundColor(to color: Color){
         selectedRectangle?.changedBackGroundColor(to: color)
+        // 배경색 모델이 바뀌었으므로 컨트롤러에게 전달
+        delegate?.BackgroundDidChanged()
         
     }
     

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -9,7 +9,6 @@ import Foundation
 
 protocol PlaneDelegate {
     func RectangleDidAdd(_ rectangle: Rectangle)
-//    func selectedRectangle(_ rectangle: Rectangle)
 //    func changedBackgroundColor()
 }
 

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -9,8 +9,10 @@ import Foundation
 
 protocol PlaneDelegate {
     func RectangleDidAdd(_ rectangle: Rectangle)
-    func BackgroundDidChanged()
-    func alpahDidChanged()
+    func BackgroundDidChanged(_ rectangle: Rectangle)
+    func alpahDidChanged(_ rectangle: Rectangle)
+    func rectangleDidMutate(_ rectangle: Rectangle)
+//    func didCancleRectangle()
 }
 
 
@@ -33,12 +35,13 @@ struct Plane{
         delegate?.RectangleDidAdd(rectangle)
     }
     
-    func ExistRectangle(at point: Point) -> Rectangle?{
+    mutating func ExistRectangle(at point: Point) -> Rectangle?{
      
         for rect in rectangles {
             if (rect.leftTopPoint.x <= point.x && rect.leftTopPoint.y <= point.y) && (rect.rightBottomPoint.x >= point.x && rect.rightBottomPoint.y >= point.y) {
                 return rect
                 }
+            
             }
         return nil
     }
@@ -46,15 +49,37 @@ struct Plane{
     func changeBackgroundColor(to color: Color){
         selectedRectangle?.changedBackGroundColor(to: color)
         // 배경색 모델이 바뀌었으므로 컨트롤러에게 전달
-        delegate?.BackgroundDidChanged()
+        delegate?.BackgroundDidChanged(selectedRectangle!)
         
     }
     
     func changeAlpha(value : Int){
         selectedRectangle?.changedAlpha(to: value)
-        delegate?.alpahDidChanged()
+        delegate?.alpahDidChanged(selectedRectangle!)
     }
     
+//    func testrect(_ rectangle: Rectangle?) {
+//        if let rectangle = rectangle {
+//            delegate?.rectangleDidMutate(rectangle)
+//        } else {
+//            delegate?.rectangleDidMutate(nil)
+//        }
+//    }
+  
+    mutating func setSelectedRectangle(_ selected: Rectangle){
+        if selected != selectedRectangle {
+            self.selectedRectangle = selected
+            delegate?.rectangleDidMutate(selected)
+            delegate?.BackgroundDidChanged(selected)
+            delegate?.alpahDidChanged(selected)
+        }
+    }
+    
+    
+    
+    
+    
+ 
 
     
 }

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol PlaneDelegate {
     func RectangleDidAdd(_ rectangle: Rectangle)
     func BackgroundDidChanged()
+    func alpahDidChanged()
 }
 
 
@@ -47,6 +48,11 @@ struct Plane{
         // 배경색 모델이 바뀌었으므로 컨트롤러에게 전달
         delegate?.BackgroundDidChanged()
         
+    }
+    
+    func changeAlpha(value : Int){
+        selectedRectangle?.changedAlpha(to: value)
+        delegate?.alpahDidChanged()
     }
     
 

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -47,24 +47,17 @@ struct Plane{
     }
     
     func changeBackgroundColor(to color: Color){
-        selectedRectangle?.changedBackGroundColor(to: color)
-        // 배경색 모델이 바뀌었으므로 컨트롤러에게 전달
-        delegate?.BackgroundDidChanged(selectedRectangle!)
+        guard let selected = selectedRectangle else { return }
+        selected.changedBackGroundColor(to: color)
+        delegate?.BackgroundDidChanged(selected)
         
     }
     
     func changeAlpha(value : Int){
-        selectedRectangle?.changedAlpha(to: value)
-        delegate?.alpahDidChanged(selectedRectangle!)
+        guard let selected = selectedRectangle else { return }
+        selected.changedAlpha(to: value)
+        delegate?.alpahDidChanged(selected)
     }
-    
-//    func testrect(_ rectangle: Rectangle?) {
-//        if let rectangle = rectangle {
-//            delegate?.rectangleDidMutate(rectangle)
-//        } else {
-//            delegate?.rectangleDidMutate(nil)
-//        }
-//    }
   
     mutating func setSelectedRectangle(_ selected: Rectangle){
         if selected != selectedRectangle {
@@ -74,12 +67,5 @@ struct Plane{
             delegate?.alpahDidChanged(selected)
         }
     }
-    
-    
-    
-    
-    
- 
-
     
 }

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol PlaneDelegate {
-    func addRectangle(_ rectangle: Rectangle)
+    func RectangleDidAdd(_ rectangle: Rectangle)
 //    func selectedRectangle(_ rectangle: Rectangle)
 //    func changedBackgroundColor()
 }
@@ -30,7 +30,7 @@ struct Plane{
     
     mutating func add(rectangle: Rectangle){
         rectangles.append(rectangle)
-        delegate?.addRectangle(rectangle)
+        delegate?.RectangleDidAdd(rectangle)
     }
     
     func ExistRectangle(at point: Point) -> Rectangle?{

--- a/DrawingApp/DrawingApp/Model/Point.swift
+++ b/DrawingApp/DrawingApp/Model/Point.swift
@@ -19,7 +19,7 @@ struct Point: CustomStringConvertible{
 
     static func randomPoint() -> Point {
         let randomX = Double.random(in: 0...850.0)
-        let randomY = Double.random(in: 0...650.0)
+        let randomY = Double.random(in: 0...550.0)
         return Point(x: randomX, y: randomY)
     }
     

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -48,6 +48,10 @@ class Rectangle: CustomStringConvertible{
     func changedBackGroundColor(to color: Color){
         self.backgroundColor = color
     }
+    
+    func changedAlpha(to value: Int){
+        self.alpha = Alpha(rawValue: value) ?? .opaque
+    }
 
 }
 

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -17,34 +17,25 @@ class CanvasView: UIView {
     var delgate: RectangleViewDelegate?
     @IBOutlet var rectangleAddButton: UIButton!
     
+    
     override init(frame: CGRect){
         super.init(frame: frame)
-        customInit()
     }
     
     required init?(coder: NSCoder){
         super.init(coder: coder)
-        customInit()
+
     }
     
-    func customInit() {
-            if let view = Bundle.main.loadNibNamed("CanvasView", owner: self, options: nil)?.first as? UIView {
-                view.frame = self.bounds
-                addSubview(view)
-            }
-        rectangleAddButton.layer.cornerRadius = 15
-        }
-    
-    
+
     @IBAction func addRectangleTouched(_ sender: Any) {
         delgate?.addRectangleButtonDidTouch()
     }
     
     @IBAction func tapAction(_ sender: UITapGestureRecognizer) {
-        let touchedPoint = sender.location(in: sender.view)
-        delgate?.canvasDidTab(at: touchedPoint)
+            let touchedPoint = sender.location(in: sender.view)
+            delgate?.canvasDidTab(at: touchedPoint)
     }
-    
     
 
         

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -7,6 +7,11 @@
 
 import UIKit
 
+protocol RectangleViewDelegate {
+    func addRectangleButtonDidTouch()
+    func canvasDidTab(at point: CGPoint)
+}
+
 class CanvasView: UIView {
     
     var delgate: RectangleViewDelegate?
@@ -32,12 +37,12 @@ class CanvasView: UIView {
     
     
     @IBAction func addRectangleTouched(_ sender: Any) {
-        delgate?.touchedAddRectangleButton()
+        delgate?.addRectangleButtonDidTouch()
     }
     
     @IBAction func tapAction(_ sender: UITapGestureRecognizer) {
         let touchedPoint = sender.location(in: sender.view)
-        delgate?.touchedCanvas(at: touchedPoint)
+        delgate?.canvasDidTab(at: touchedPoint)
     }
     
     

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -18,13 +18,14 @@ class CanvasView: UIView {
     @IBOutlet var rectangleAddButton: UIButton!
     
     
-    override init(frame: CGRect){
-        super.init(frame: frame)
+    override func awakeFromNib(){
+        self.rectangleAddButton.layer.cornerRadius = 15
     }
+    
     
     required init?(coder: NSCoder){
         super.init(coder: coder)
-
+//        self.rectangleAddButton.layer.cornerRadius = 15
     }
     
 

--- a/DrawingApp/DrawingApp/View/CanvasView.xib
+++ b/DrawingApp/DrawingApp/View/CanvasView.xib
@@ -8,13 +8,9 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CanvasView" customModule="DrawingApp" customModuleProvider="target">
-            <connections>
-                <outlet property="rectangleAddButton" destination="s0d-wu-ett" id="KJW-1h-RMf"/>
-            </connections>
-        </placeholder>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="CanvasView" customModule="DrawingApp" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="1180" height="820"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
@@ -29,7 +25,7 @@
                         <fontDescription key="titleFontDescription" type="system" pointSize="20"/>
                     </buttonConfiguration>
                     <connections>
-                        <action selector="addRectangleTouched:" destination="-1" eventType="touchUpInside" id="IYh-CF-aze"/>
+                        <action selector="addRectangleTouched:" destination="iN0-l3-epB" eventType="touchUpInside" id="SRO-iC-vFk"/>
                     </connections>
                 </button>
             </subviews>
@@ -37,13 +33,14 @@
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <gestureRecognizers/>
             <connections>
+                <outlet property="rectangleAddButton" destination="s0d-wu-ett" id="l4c-BE-XIt"/>
                 <outletCollection property="gestureRecognizers" destination="hI1-Zi-Khl" appends="YES" id="R03-0B-bxA"/>
             </connections>
             <point key="canvasLocation" x="138.81355932203391" y="114.8780487804878"/>
         </view>
         <tapGestureRecognizer id="hI1-Zi-Khl">
             <connections>
-                <action selector="tapAction:" destination="-1" id="gEs-ha-UA2"/>
+                <action selector="tapAction:" destination="iN0-l3-epB" id="13r-7a-mdt"/>
             </connections>
         </tapGestureRecognizer>
     </objects>

--- a/DrawingApp/DrawingApp/View/ControllerView.swift
+++ b/DrawingApp/DrawingApp/View/ControllerView.swift
@@ -10,11 +10,13 @@ import UIKit
 
 protocol ControllerViewDelegate {
     func backgroundButtonDidTouch()
+    func alphaSliderDidChange(_ value: Float)
 }
 
 
 class ControllerView: UIView {
 
+    @IBOutlet var alphaSlider: UISlider!
     @IBOutlet var backgroundButton: UIButton!
     var delegate: ControllerViewDelegate?
     
@@ -40,5 +42,8 @@ class ControllerView: UIView {
         delegate?.backgroundButtonDidTouch()
     }
     
+    @IBAction func changedAlphaSlider(_ sender: UISlider) {
+        delegate?.alphaSliderDidChange(sender.value)
+    }
     
 }

--- a/DrawingApp/DrawingApp/View/ControllerView.swift
+++ b/DrawingApp/DrawingApp/View/ControllerView.swift
@@ -15,6 +15,7 @@ protocol ControllerViewDelegate {
 
 class ControllerView: UIView {
 
+    @IBOutlet var backgroundButton: UIButton!
     var delegate: ControllerViewDelegate?
     
     override init(frame: CGRect){
@@ -38,4 +39,6 @@ class ControllerView: UIView {
     @IBAction func touchedBackgroundButton(_ sender: Any) {
         delegate?.backgroundButtonDidTouch()
     }
+    
+    
 }

--- a/DrawingApp/DrawingApp/View/ControllerView.swift
+++ b/DrawingApp/DrawingApp/View/ControllerView.swift
@@ -21,10 +21,6 @@ class ControllerView: UIView {
     
     var delegate: ControllerViewDelegate?
     
-    override init(frame: CGRect){
-        super.init(frame: frame)
-    }
-    
     required init?(coder: NSCoder){
         super.init(coder: coder)
     }

--- a/DrawingApp/DrawingApp/View/ControllerView.swift
+++ b/DrawingApp/DrawingApp/View/ControllerView.swift
@@ -7,6 +7,12 @@
 
 import UIKit
 
+
+protocol ControllerViewDelegate {
+    func backgroundButtonDidTouch()
+}
+
+
 class ControllerView: UIView {
 
     var delegate: ControllerViewDelegate?
@@ -30,6 +36,6 @@ class ControllerView: UIView {
         }
 
     @IBAction func touchedBackgroundButton(_ sender: Any) {
-        delegate?.touchedBackgroundButton()
+        delegate?.backgroundButtonDidTouch()
     }
 }

--- a/DrawingApp/DrawingApp/View/ControllerView.swift
+++ b/DrawingApp/DrawingApp/View/ControllerView.swift
@@ -16,34 +16,26 @@ protocol ControllerViewDelegate {
 
 class ControllerView: UIView {
 
-    @IBOutlet var alphaSlider: UISlider!
     @IBOutlet var backgroundButton: UIButton!
+    @IBOutlet var alphaSlider: UISlider!
+    
     var delegate: ControllerViewDelegate?
     
     override init(frame: CGRect){
         super.init(frame: frame)
-        customInit()
     }
     
     required init?(coder: NSCoder){
         super.init(coder: coder)
-        customInit()
     }
     
-    
-    func customInit() {
-            if let view = Bundle.main.loadNibNamed("ControllerView", owner: self, options: nil)?.first as? UIView {
-                view.frame = self.bounds
-                addSubview(view)
-            }
-        }
 
-    @IBAction func touchedBackgroundButton(_ sender: Any) {
-        delegate?.backgroundButtonDidTouch()
+    @IBAction func touchBackgroundButton(_ sender: Any) {
+            delegate?.backgroundButtonDidTouch()
     }
     
+   
     @IBAction func changedAlphaSlider(_ sender: UISlider) {
-        delegate?.alphaSliderDidChange(sender.value)
+            delegate?.alphaSliderDidChange(sender.value)
     }
-    
 }

--- a/DrawingApp/DrawingApp/View/ControllerView.xib
+++ b/DrawingApp/DrawingApp/View/ControllerView.xib
@@ -10,6 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ControllerView" customModule="DrawingApp" customModuleProvider="target">
             <connections>
+                <outlet property="alphaSlider" destination="GbY-4l-0Kf" id="tn2-ok-kfQ"/>
                 <outlet property="backgroundButton" destination="jvT-O5-KSV" id="cFd-nL-5RF"/>
             </connections>
         </placeholder>
@@ -42,17 +43,20 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="GbY-4l-0Kf">
+                <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="5" minValue="1" maxValue="10" translatesAutoresizingMaskIntoConstraints="NO" id="GbY-4l-0Kf">
                     <rect key="frame" x="31" y="180" width="134" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <color key="tintColor" red="0.44705882349999998" green="0.53725490200000003" blue="0.77647058820000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <color key="thumbTintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <connections>
+                        <action selector="changedAlphaSlider:" destination="-1" eventType="valueChanged" id="iL7-H4-ebh"/>
+                    </connections>
                 </slider>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemGray5Color"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-28.220338983050848" y="105.36585365853658"/>
+            <point key="canvasLocation" x="-31" y="107"/>
         </view>
     </objects>
     <resources>

--- a/DrawingApp/DrawingApp/View/ControllerView.xib
+++ b/DrawingApp/DrawingApp/View/ControllerView.xib
@@ -8,7 +8,11 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ControllerView" customModule="DrawingApp" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ControllerView" customModule="DrawingApp" customModuleProvider="target">
+            <connections>
+                <outlet property="backgroundButton" destination="jvT-O5-KSV" id="cFd-nL-5RF"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="197" height="820"/>

--- a/DrawingApp/DrawingApp/View/ControllerView.xib
+++ b/DrawingApp/DrawingApp/View/ControllerView.xib
@@ -31,7 +31,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <color key="tintColor" red="0.44705882349999998" green="0.53725490200000003" blue="0.77647058820000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <state key="normal" title="Button"/>
-                    <buttonConfiguration key="configuration" style="filled" title="Button"/>
+                    <buttonConfiguration key="configuration" style="filled" title="None"/>
                     <connections>
                         <action selector="touchedBackgroundButton:" destination="-1" eventType="touchUpInside" id="6MU-XV-ytn"/>
                     </connections>
@@ -43,7 +43,7 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="5" minValue="1" maxValue="10" translatesAutoresizingMaskIntoConstraints="NO" id="GbY-4l-0Kf">
+                <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="1" maxValue="10" translatesAutoresizingMaskIntoConstraints="NO" id="GbY-4l-0Kf">
                     <rect key="frame" x="31" y="180" width="134" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <color key="tintColor" red="0.44705882349999998" green="0.53725490200000003" blue="0.77647058820000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/DrawingApp/DrawingApp/View/ControllerView.xib
+++ b/DrawingApp/DrawingApp/View/ControllerView.xib
@@ -8,14 +8,9 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ControllerView" customModule="DrawingApp" customModuleProvider="target">
-            <connections>
-                <outlet property="alphaSlider" destination="GbY-4l-0Kf" id="tn2-ok-kfQ"/>
-                <outlet property="backgroundButton" destination="jvT-O5-KSV" id="cFd-nL-5RF"/>
-            </connections>
-        </placeholder>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ControllerView" customModule="DrawingApp" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="197" height="820"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
@@ -33,7 +28,7 @@
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="filled" title="None"/>
                     <connections>
-                        <action selector="touchedBackgroundButton:" destination="-1" eventType="touchUpInside" id="6MU-XV-ytn"/>
+                        <action selector="touchBackgroundButton:" destination="iN0-l3-epB" eventType="touchUpInside" id="kr1-mr-xj9"/>
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="투명도" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TIw-dX-TgL">
@@ -49,13 +44,17 @@
                     <color key="tintColor" red="0.44705882349999998" green="0.53725490200000003" blue="0.77647058820000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <color key="thumbTintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>
-                        <action selector="changedAlphaSlider:" destination="-1" eventType="valueChanged" id="iL7-H4-ebh"/>
+                        <action selector="changedAlphaSlider:" destination="iN0-l3-epB" eventType="valueChanged" id="qcs-dg-d1s"/>
                     </connections>
                 </slider>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemGray5Color"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="alphaSlider" destination="GbY-4l-0Kf" id="h2L-vq-ZMQ"/>
+                <outlet property="backgroundButton" destination="jvT-O5-KSV" id="PtU-Wo-CsV"/>
+            </connections>
             <point key="canvasLocation" x="-31" y="107"/>
         </view>
     </objects>

--- a/DrawingApp/DrawingApp/View/RectangleViewDelegate.swift
+++ b/DrawingApp/DrawingApp/View/RectangleViewDelegate.swift
@@ -8,12 +8,4 @@
 import Foundation
 import UIKit
 
-protocol RectangleViewDelegate {
-    
-    func touchedAddRectangleButton()
-    func touchedCanvas(at point: CGPoint)
-}
 
-protocol ControllerViewDelegate {
-    func touchedBackgroundButton()
-}

--- a/DrawingApp/DrawingApp/ViewController/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController/ViewController.swift
@@ -52,8 +52,7 @@ extension ViewController: RectangleViewDelegate {
 
 // Delegate : Model
 extension ViewController: PlaneDelegate {
-    func selectedRectangle(_ rectangle: Rectangle) {
-    }
+ 
 
     func RectangleDidAdd(_ rectangle: Rectangle) {
         let rect = UIView(frame: CGRect(x: rectangle.position.x, y: rectangle.position.y, width: rectangle.size.width, height: rectangle.size.height))
@@ -76,5 +75,8 @@ extension ViewController: ControllerViewDelegate {
         let changedColor = Color.randomColor()
         selectedRectangleView?.backgroundColor = Convertor.convertColor(from: changedColor)
         plane.changeBackgroundColor(to: changedColor)
+        
+        // 모델에게 해당 Rect의 색이 변경되었음을 알려주기
+        plane.selectedRectangle?.changedBackGroundColor(to: Convertor.convertColor(from: selectedRectangleView?.backgroundColor ?? UIColor()))
     }
 }

--- a/DrawingApp/DrawingApp/ViewController/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController/ViewController.swift
@@ -39,10 +39,11 @@ extension ViewController: RectangleViewDelegate {
             
             if rectangleViews[selected] != selectedRectangleView {
                 selectedRectangleView?.layer.borderWidth = 0
-                controllerView.alphaSlider.setValue(Float(selectedRectangleView?.alpha ?? 1.0) * 10 , animated: true)
-                controllerView.backgroundButton.setTitle(selectedRectangleView?.backgroundColor?.convertHex(), for: .normal)
             }
+            
             selectedRectangleView = rectangleViews[selected]
+            controllerView.alphaSlider.setValue(Float(selectedRectangleView?.alpha ?? 1.0) * 10 , animated: true)
+            controllerView.backgroundButton.setTitle(selectedRectangleView?.backgroundColor?.convertHex(), for: .normal)
             selectedRectangleView?.layer.borderWidth = 5
             plane.selectedRectangle = selected
             

--- a/DrawingApp/DrawingApp/ViewController/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController/ViewController.swift
@@ -52,7 +52,6 @@ extension ViewController: RectangleViewDelegate {
 
 // Delegate : Model
 extension ViewController: PlaneDelegate {
- 
 
     func RectangleDidAdd(_ rectangle: Rectangle) {
         let rect = UIView(frame: CGRect(x: rectangle.position.x, y: rectangle.position.y, width: rectangle.size.width, height: rectangle.size.height))
@@ -63,7 +62,12 @@ extension ViewController: PlaneDelegate {
         rect.isUserInteractionEnabled = false
         
         rectangleViews[rectangle] = rect
-        
+    }
+    
+    func BackgroundDidChanged() {
+        // 뷰의 배경색 버튼 Label을 변경 (16진수로 변환한다)
+        let hexString = selectedRectangleView?.backgroundColor?.convertHex()
+        controllerView.backgroundButton.setTitle(hexString, for: .normal)
     }
     
 }
@@ -77,6 +81,7 @@ extension ViewController: ControllerViewDelegate {
         plane.changeBackgroundColor(to: changedColor)
         
         // 모델에게 해당 Rect의 색이 변경되었음을 알려주기
-        plane.selectedRectangle?.changedBackGroundColor(to: Convertor.convertColor(from: selectedRectangleView?.backgroundColor ?? UIColor()))
+        plane.selectedRectangle?.changedBackGroundColor(to: changedColor)
+        
     }
 }

--- a/DrawingApp/DrawingApp/ViewController/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController/ViewController.swift
@@ -70,6 +70,13 @@ extension ViewController: PlaneDelegate {
         controllerView.backgroundButton.setTitle(hexString, for: .normal)
     }
     
+    func alpahDidChanged() {
+        if let alpha = selectedRectangleView?.alpha {
+            controllerView.alphaSlider.setValue(Float(alpha) * 10, animated: false)
+            
+        }
+    }
+    
 }
 
 
@@ -82,6 +89,13 @@ extension ViewController: ControllerViewDelegate {
         
         // 모델에게 해당 Rect의 색이 변경되었음을 알려주기
         plane.selectedRectangle?.changedBackGroundColor(to: changedColor)
+    }
+    
+    func alphaSliderDidChange(_ value: Float) {
+        selectedRectangleView?.alpha = CGFloat(value) / 10.0
+        plane.changeAlpha(value: Int(value))
         
     }
 }
+
+

--- a/DrawingApp/DrawingApp/ViewController/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController/ViewController.swift
@@ -14,15 +14,27 @@ class ViewController: UIViewController {
     let factory = RectangleFactory()
     private var selectedRectangleView: UIView?
     var rectangleViews = [Rectangle : UIView]()
-    
-    @IBOutlet var canvasView: CanvasView!
-    @IBOutlet var controllerView: ControllerView!
+
+    var controllerView: ControllerView!
+    var canvasView: CanvasView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        controllerView = Bundle.main.loadNibNamed("ControllerView", owner: self, options: nil)?.first as! ControllerView
+        canvasView = Bundle.main.loadNibNamed("CanvasView", owner: self, options: nil)?.first as! CanvasView
+        
+        self.view.addSubview(canvasView)
+        self.view.addSubview(controllerView)
+        
+        controllerView.translatesAutoresizingMaskIntoConstraints = false
+        controllerView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor).isActive = true
+        controllerView.widthAnchor.constraint(equalToConstant: 197).isActive = true
+        controllerView.heightAnchor.constraint(equalToConstant: 820).isActive = true
+
         plane.delegate = self
-        canvasView.delgate = self
         controllerView.delegate = self
+        canvasView.delgate = self
     }
     
     func clear() {

--- a/DrawingApp/DrawingApp/ViewController/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController/ViewController.swift
@@ -37,16 +37,17 @@ extension ViewController: RectangleViewDelegate {
         let touchedPoint = Point(x: point.x, y: point.y)
         if let selected = plane.ExistRectangle(at: touchedPoint) {
             
+            // 다른 사각형을 선택했을때, 이전 사각형 테두리 지워주기
             if rectangleViews[selected] != selectedRectangleView {
                 selectedRectangleView?.layer.borderWidth = 0
             }
             
+            // 선택한 사각형에 대한 속성을 컨트롤러 뷰에 표현, 테두리 표시
             selectedRectangleView = rectangleViews[selected]
             controllerView.alphaSlider.setValue(Float(selectedRectangleView?.alpha ?? 1.0) * 10 , animated: true)
             controllerView.backgroundButton.setTitle(selectedRectangleView?.backgroundColor?.convertHex(), for: .normal)
             selectedRectangleView?.layer.borderWidth = 5
-            plane.selectedRectangle = selected
-            
+            selectedRectangleView?.layer.borderColor = CGColor(red: 1, green: 0, blue: 0, alpha: 1)
         } else {
             selectedRectangleView?.layer.borderWidth = 0
         }
@@ -58,17 +59,18 @@ extension ViewController: PlaneDelegate {
 
     func RectangleDidAdd(_ rectangle: Rectangle) {
         let rect = UIView(frame: CGRect(x: rectangle.position.x, y: rectangle.position.y, width: rectangle.size.width, height: rectangle.size.height))
-        rect.backgroundColor = Convertor.convertColor(from: rectangle.backgroundColor)
-        rect.alpha = Double(rectangle.alpha.rawValue) * 0.1
+//        rect.backgroundColor = Convertor.convertColor(from: rectangle.backgroundColor)
+        let alpha = Double(rectangle.alpha.rawValue) * 0.1
+        let color = Convertor.convertColor(from: rectangle.backgroundColor, alpha: alpha)
+        rect.backgroundColor = color
+        
         self.canvasView.addSubview(rect)
-        rect.layer.borderColor = CGColor(red: 1, green: 0, blue: 0, alpha: 1)
         rect.isUserInteractionEnabled = false
         
         rectangleViews[rectangle] = rect
     }
     
     func BackgroundDidChanged() {
-        // 뷰의 배경색 버튼 Label을 변경 (16진수로 변환한다)
         let hexString = selectedRectangleView?.backgroundColor?.convertHex()
         controllerView.backgroundButton.setTitle(hexString, for: .normal)
     }
@@ -86,7 +88,8 @@ extension ViewController: ControllerViewDelegate {
     
     func backgroundButtonDidTouch() {
         let changedColor = Color.randomColor()
-        selectedRectangleView?.backgroundColor = Convertor.convertColor(from: changedColor)
+        guard let selected = selectedRectangleView else { return }
+        selected.backgroundColor = Convertor.convertColor(from: changedColor, alpha: selected.alpha)
         plane.changeBackgroundColor(to: changedColor)
         
         // 모델에게 해당 Rect의 색이 변경되었음을 알려주기

--- a/DrawingApp/DrawingApp/ViewController/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController/ViewController.swift
@@ -44,28 +44,10 @@ extension ViewController: RectangleViewDelegate {
     func canvasDidTab(at point: CGPoint) {
         let touchedPoint = Point(x: point.x, y: point.y)
         if let selected = plane.ExistRectangle(at: touchedPoint) {
-            // 선택된게 있을때
-            plane.setSelectedRectangle(selected) // 모델에 추가 -> 델리게이트
+            plane.setSelectedRectangle(selected)
             selectedRectangleView = rectangleViews[selected]
-            
-            
-            // 다른 사각형을 선택했을때, 이전 사각형 테두리 지워주기
-//            if rectangleViews[selected] != selectedRectangleView {
-//                selectedRectangleView?.layer.borderWidth = 0
-//            }
-            
-            // 선택한 사각형에 대한 속성을 컨트롤러 뷰에 표현, 테두리 표시
-//            selectedRectangleView = rectangleViews[selected]
-//            controllerView.alphaSlider.setValue(Float(selectedRectangleView?.alpha ?? 1.0) * 10 , animated: true)
-//            controllerView.backgroundButton.setTitle(selectedRectangleView?.backgroundColor?.convertHex(), for: .normal)
-//            selectedRectangleView?.layer.borderWidth = 5
-//            selectedRectangleView?.layer.borderColor = CGColor(red: 1, green: 0, blue: 0, alpha: 1)
-            
-            
-            // 선택된 사각형이 없는 경우 이전 사각형 border 지우기
         } else {
-            clear()
-
+            clear()  // 선택된 사각형이 없는 경우
         }
     }
 }
@@ -77,24 +59,15 @@ extension ViewController: PlaneDelegate {
         selectedRectangleView?.layer.borderWidth = 0 // 이전 사각형테두리 지우기
         selectedRectangleView = rectangleViews[selected]
         selectedRectangleView?.layer.borderWidth = 5
-        
-//        selectedRectangleView?.backgroundColor?.withAlphaComponent(selectedRectangleView!.alpha)
-        
-        
-        
-        
     }
     
 
     func RectangleDidAdd(_ rectangle: Rectangle) {
         let rect = UIView(frame: CGRect(x: rectangle.position.x, y: rectangle.position.y, width: rectangle.size.width, height: rectangle.size.height))
-//        let alpha = Double(rectangle.alpha.rawValue) * 0.1
         let color = Convertor.convertColor(from: rectangle.backgroundColor, alpha: rectangle.alpha)
         rect.backgroundColor = color
-        
         self.canvasView.addSubview(rect)
         rect.isUserInteractionEnabled = false
-        
         rectangleViews[rectangle] = rect
     }
     
@@ -122,13 +95,10 @@ extension ViewController: ControllerViewDelegate {
     func backgroundButtonDidTouch() {
         let changedColor = Color.randomColor()
         plane.changeBackgroundColor(to: changedColor)
-        
     }
     
     func alphaSliderDidChange(_ value: Float) {
-//        selectedRectangleView?.alpha = CGFloat(value) / 10.0
         plane.changeAlpha(value: Int(value))
-        
     }
 }
 

--- a/DrawingApp/DrawingApp/ViewController/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController/ViewController.swift
@@ -12,7 +12,7 @@ class ViewController: UIViewController {
 
     var plane = Plane()
     let factory = RectangleFactory()
-    var selectedRectangleView: UIView?
+    private var selectedRectangleView: UIView?
     var rectangleViews = [Rectangle : UIView]()
     
     @IBOutlet var canvasView: CanvasView!
@@ -28,12 +28,12 @@ class ViewController: UIViewController {
 }
 // Delegate : View
 extension ViewController: RectangleViewDelegate {
-    
-    func touchedAddRectangleButton() {
+   
+    func addRectangleButtonDidTouch() {
         plane.add(rectangle: factory.createRandomRectangle())
     }
     
-    func touchedCanvas(at point: CGPoint) {
+    func canvasDidTab(at point: CGPoint) {
         let touchedPoint = Point(x: point.x, y: point.y)
         if let selected = plane.ExistRectangle(at: touchedPoint) {
             
@@ -55,7 +55,7 @@ extension ViewController: PlaneDelegate {
     func selectedRectangle(_ rectangle: Rectangle) {
     }
 
-    func addRectangle(_ rectangle: Rectangle) {
+    func RectangleDidAdd(_ rectangle: Rectangle) {
         let rect = UIView(frame: CGRect(x: rectangle.position.x, y: rectangle.position.y, width: rectangle.size.width, height: rectangle.size.height))
         rect.backgroundColor = Convertor.convertColor(from: rectangle.backgroundColor)
         rect.alpha = Double(rectangle.alpha.rawValue) * 0.1
@@ -71,7 +71,8 @@ extension ViewController: PlaneDelegate {
 
 
 extension ViewController: ControllerViewDelegate {
-    func touchedBackgroundButton() {
+    
+    func backgroundButtonDidTouch() {
         let changedColor = Color.randomColor()
         selectedRectangleView?.backgroundColor = Convertor.convertColor(from: changedColor)
         plane.changeBackgroundColor(to: changedColor)

--- a/DrawingApp/DrawingApp/ViewController/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController/ViewController.swift
@@ -39,6 +39,8 @@ extension ViewController: RectangleViewDelegate {
             
             if rectangleViews[selected] != selectedRectangleView {
                 selectedRectangleView?.layer.borderWidth = 0
+                controllerView.alphaSlider.setValue(Float(selectedRectangleView?.alpha ?? 1.0) * 10 , animated: true)
+                controllerView.backgroundButton.setTitle(selectedRectangleView?.backgroundColor?.convertHex(), for: .normal)
             }
             selectedRectangleView = rectangleViews[selected]
             selectedRectangleView?.layer.borderWidth = 5
@@ -73,7 +75,6 @@ extension ViewController: PlaneDelegate {
     func alpahDidChanged() {
         if let alpha = selectedRectangleView?.alpha {
             controllerView.alphaSlider.setValue(Float(alpha) * 10, animated: false)
-            
         }
     }
     


### PR DESCRIPTION
![Simulator Screen Recording - iPad Air (4th generation) - 2022-03-16 at 02 23 52](https://user-images.githubusercontent.com/59790540/158438153-dc734424-0604-4afc-964c-8ea9a0ebfce9.gif)

** xib 수정후에는 아래 사각형 라운드 처리 x ** 

### **작업 목록**

- [x]  사각형 터치시 현재 색 표시
- [x]  사각형 터치시 현재 투명도 값 표시
- [x]  Alpha slider 로 사각형 투명도 조절하기

### **학습 키워드**

- 

### **질문거리**

- ~~지난 피드백에 xib를 subview로 추가하지않고 ViewController에서 CustomView를 불러오는 방식으로 다뤄보라고 하셔서 시도해보았으나 오류가 발생했습니다.~~  해결되었습니다.. 

테스트로 ControllerView xib만 시도해보았을때의 과정입니다. 

file’s Owner 에서 CustomClass 를 지정한것을 해제하고 뷰 자체의 CustomClass 를 `ControllerView` 로 설정해주었습니다 . 

원래 IBOutlet연결들은 file’s owner로 연결되어있어서 해제하고, 설정해주었던 클래스파일과 다시 IBoutlet들을 연결해주었습니다. 

ViewController에서 뷰를 불러왔습니다. 

```swift
override viewDidLoad() { 
...
let view = Bundle.main.loadNibNamed("ControllerView", owner: self, options: nil)?.first as! ControllerView
        controllerView.addSubview(view)
}
```

~~이후 controllerView 내부 프로퍼티에 접근할때 계속해서 nil 값이 반환되는 문제점이 발생합니다..~~ 

<br>
<br> 

- Custom 뷰들을 불러오는 방법을 개선한 후, CustomView 파일 안에서 컴포넌트들의 속성을 변경할때 에러가 발생하는 문제가 있습니다

```swift
override init(frame: CGRect){
        super.init(frame: frame)
        self.rectangleAddButton.layer.cornerRadius = 15 // nil error 
    }
    
    required init?(coder: NSCoder){
        super.init(coder: coder)
        self.rectangleAddButton.layer.cornerRadius = 15 // nil error 
    }
```

상위 모듈에서 접근해서 바꿔주는 방법도 있지만 좋은 방법은 아닌것 같고.. 어떤것을 찾아봐야 하는지 감이 안잡혀서 질문 드립니다ㅠ 

### 고민과 해결

수업을 들은 후, 코드를 보니 입출력이 잘 구분되어 있지 않다고 판단되어 흐름을 다시 파악한 후 구현해보았습니다. 

Alpha 값을 슬라이더로 조정시, 선택된 사각형의 border 까지 투명도가 조절이 되는 문제점

→ ``UIView.alpha``로 값을 set하면 ``UIView.layer.borderColor``의 alpha 값도 같이 set 되기 때문이었습니다. background나 alpha값을 바꿔줄때 Model에서 Color,Alpha 값을 얻어와 다시 UIColor를 만들고 셋팅해주어 해결했습니다.