### PR TITLE
[Beck] Step5 - Touch and Drag 1

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -615,6 +615,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -643,6 +644,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1B1D7E0627E3510400683FA9 /* FactoryMainScreenRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1D7E0527E3510400683FA9 /* FactoryMainScreenRectangle.swift */; };
 		1B4A55AA27CD99EC009CDC7B /* RandomizeValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4A55A927CD99EC009CDC7B /* RandomizeValue.swift */; };
 		1B4A55AC27CD9F96009CDC7B /* RectanglePropertyCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4A55AB27CD9F96009CDC7B /* RectanglePropertyCreator.swift */; };
 		1B54997127D09BE30086EC5F /* Plane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B54997027D09BE30086EC5F /* Plane.swift */; };
@@ -61,6 +62,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1B1D7E0527E3510400683FA9 /* FactoryMainScreenRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactoryMainScreenRectangle.swift; sourceTree = "<group>"; };
 		1B4A55A927CD99EC009CDC7B /* RandomizeValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomizeValue.swift; sourceTree = "<group>"; };
 		1B4A55AB27CD9F96009CDC7B /* RectanglePropertyCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectanglePropertyCreator.swift; sourceTree = "<group>"; };
 		1B54997027D09BE30086EC5F /* Plane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plane.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				1B54997A27D0B4C00086EC5F /* Rectangle.swift */,
 				1BD3EA2827E1DC4600ADB359 /* ColoredRectangle.swift */,
 				1BD3EA2A27E1DC4F00ADB359 /* ImageRectangle.swift */,
+				1B1D7E0527E3510400683FA9 /* FactoryMainScreenRectangle.swift */,
 			);
 			path = Rectangle;
 			sourceTree = "<group>";
@@ -420,6 +423,7 @@
 				1BD7287427CCBC7A008DED9E /* SceneDelegate.swift in Sources */,
 				1B54997427D0A21F0086EC5F /* UIView+Extension.swift in Sources */,
 				1B4A55AA27CD99EC009CDC7B /* RandomizeValue.swift in Sources */,
+				1B1D7E0627E3510400683FA9 /* FactoryMainScreenRectangle.swift in Sources */,
 				1BD3EA2927E1DC4600ADB359 /* ColoredRectangle.swift in Sources */,
 				1BD728B027CD0E88008DED9E /* SystemLog.swift in Sources */,
 				1BD728AB27CCFB8D008DED9E /* FactoryRectangleProperty.swift in Sources */,

--- a/DrawingApp/DrawingApp/Models/Plane.swift
+++ b/DrawingApp/DrawingApp/Models/Plane.swift
@@ -12,6 +12,8 @@ import Foundation
 protocol MainSceneTapDelegate {
     // 델리게이트 패턴의 메소드는 어떤 요소가 언제 누가 선택되었는지 명시하기 위해 네이밍을 변경하였습니다.
     func didSelect(at index: Int?)
+    func getRectangleModel(at index: Int)->RectangleProperty?
+    func didMoved(rect point: RectOrigin, at index: Int)
 }
 
 /// ViewController와 MainScreenViewController 사이를 잇고, 생성된 사각형의 모델들을 저장하는 모델입니다.
@@ -105,6 +107,11 @@ final class Plane: MainSceneTapDelegate {
         NotificationCenter.default.post(noti) // Plane.alphaDidChanged
     }
     
+    func didMoved(rect point: RectOrigin, at index: Int) {
+        guard (0..<rectangleModels.endIndex) ~= index else { return }
+        rectangleModels[index].setPoint(point)
+    }
+    
     // MARK: - RectangleViewTapDelegate implementation
     func didSelect(at index: Int?) {
         guard -1..<rectangleModels.endIndex ~= (index ?? -1) else {
@@ -124,6 +131,10 @@ final class Plane: MainSceneTapDelegate {
         }
         
         NotificationCenter.default.post(noti) // Plane.rectangleViewTouched
+    }
+    
+    func getRectangleModel(at index: Int) -> RectangleProperty? {
+        getRectangleProperty(at: index)
     }
     
     // MARK: - Plane no using Interface

--- a/DrawingApp/DrawingApp/Views/Base.lproj/Main.storyboard
+++ b/DrawingApp/DrawingApp/Views/Base.lproj/Main.storyboard
@@ -195,16 +195,8 @@
                         <viewLayoutGuide key="safeArea" id="2m4-7r-jvv"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <connections>
-                        <outlet property="tapGesture" destination="yTy-GT-aHK" id="8IT-V5-1gu"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5vn-HN-Bl0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <tapGestureRecognizer id="yTy-GT-aHK">
-                    <connections>
-                        <outlet property="delegate" destination="mMi-uD-Q6q" id="dxq-PD-xax"/>
-                    </connections>
-                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-665" y="853"/>
         </scene>

--- a/DrawingApp/DrawingApp/Views/MainScreenViewController.swift
+++ b/DrawingApp/DrawingApp/Views/MainScreenViewController.swift
@@ -150,8 +150,9 @@ final class MainScreenViewController: UIViewController {
     @objc func drag(_ sender: UIPanGestureRecognizer) {
         guard let rect = sender.view as? Rectangle else { return }
         
+        // panGesture가 끝났기 때문에 copiedView를 rectangle이 있던 자리를 차지하도록 하고, 기존 이동하던 rectangle은 지웁니다.
         if sender.state == .ended, let copiedView = rect.copiedView {
-            rect.addGestureRecognizer(selectGesture)
+            copiedView.addGestureRecognizer(selectGesture)
             
             let origin = RectOrigin(x: rect.frame.minX, y: rect.frame.minY)
             let index = rect.index
@@ -184,6 +185,7 @@ extension MainScreenViewController: UIGestureRecognizerDelegate {
             return
         }
         
+        // 처음 rectangle을 선택하면 두 손가락으로 선택하는 제스쳐, 팬 제스쳐를 추가하여 임시 뷰 생성 및 이동이 가능하도록 합니다.
         if touches.count == 1 {
             rectangleDelegate?.didSelect(at: rect.index)
             rect.addGestureRecognizer(doubleTouchesCopyGesture)
@@ -204,7 +206,8 @@ extension MainScreenViewController: UIGestureRecognizerDelegate {
         else {
             return true
         }
-
+        
+        // 두 손가락으로 선택하는 제스쳐로 뷰를 복사하고 선택 효과는 낼 수 없게 만듭니다. 선택 효과를 내는 제스쳐와 두 손가락 제스쳐가 겹쳐서 오류가 발생하였습니다.
         view.insertSubview(copiedView, belowSubview: rect)
 
         rect.setCopiedView(rect: copiedView)
@@ -215,8 +218,10 @@ extension MainScreenViewController: UIGestureRecognizerDelegate {
     
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesEnded(touches, with: event)
+        
         guard let rect = touches.first?.view as? Rectangle, let copiedView = rect.copiedView else { return }
         
+        // 만약 임시 뷰가 있음에도 이동이 없었던 경우라면 rectangle이 임시뷰 역할을 하지 않도록 하고, 복사된 뷰는 제거합니다.
         if rect.frame.origin == copiedView.frame.origin {
             copiedView.removeFromSuperview()
             rect.setAlpha((rectangleDelegate?.getRectangleModel(at: rect.index)?.alpha ?? 1)/10)

--- a/DrawingApp/DrawingApp/Views/MainScreenViewController.swift
+++ b/DrawingApp/DrawingApp/Views/MainScreenViewController.swift
@@ -15,6 +15,8 @@ final class MainScreenViewController: UIViewController, UIGestureRecognizerDeleg
     
     var rectangleDelegate: MainSceneTapDelegate?
     
+    private let factoryRectangle = FactoryMainScreenRectangle()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -96,17 +98,7 @@ final class MainScreenViewController: UIViewController, UIGestureRecognizerDeleg
             return
         }
         
-        var rect: Rectangle!
-        
-        switch model {
-        case let model as ImageRectangleProperty:
-            rect = ImageRectangle(model: model, index: index)
-        case let model as ColoredRectangleProperty:
-            rect = ColoredRectangle(model: model, index: index)
-        default:
-            LoggerUtil.debugLog(message: "Initialize rectangle failed. \(model.name)")
-            return
-        }
+        guard let rect = factoryRectangle.makeRectangle(from: model, at: index) else { return }
         
         rectangleViews.append(rect)
         view.addSubview(rect)

--- a/DrawingApp/DrawingApp/Views/Rectangle/FactoryMainScreenRectangle.swift
+++ b/DrawingApp/DrawingApp/Views/Rectangle/FactoryMainScreenRectangle.swift
@@ -1,0 +1,22 @@
+//
+//  FactoryMainScreenRectangle.swift
+//  DrawingApp
+//
+//  Created by 백상휘 on 2022/03/17.
+//
+
+import Foundation
+
+final class FactoryMainScreenRectangle {
+    func makeRectangle(from model: RectangleProperty, at index: Int) -> Rectangle? {
+        switch model {
+        case let model as ImageRectangleProperty:
+            return ImageRectangle(model: model, index: index)
+        case let model as ColoredRectangleProperty:
+            return ColoredRectangle(model: model, index: index)
+        default:
+            LoggerUtil.debugLog(message: "Initialize rectangle failed. \(model.name)")
+            return nil
+        }
+    }
+}

--- a/DrawingApp/DrawingApp/Views/Rectangle/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Views/Rectangle/Rectangle.swift
@@ -21,6 +21,7 @@ protocol EnableSetAlphaRectangle {
 class Rectangle: UIView, IndexedRectangle {
     
     var index: Int = 0
+    // copiedView 변수는 Rectangle이 바로 참조할 수 있도록 하기 위함입니다.
     private(set) var copiedView: Rectangle?
     
     var isSelected = false {

--- a/DrawingApp/DrawingApp/Views/Rectangle/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Views/Rectangle/Rectangle.swift
@@ -21,6 +21,7 @@ protocol EnableSetAlphaRectangle {
 class Rectangle: UIView, IndexedRectangle {
     
     var index: Int = 0
+    private(set) var copiedView: Rectangle?
     
     var isSelected = false {
         didSet {
@@ -35,5 +36,32 @@ class Rectangle: UIView, IndexedRectangle {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+    }
+    
+    func setCopiedView(rect: Rectangle) {
+        copiedView = rect
+    }
+    
+    func setAlpha(_ alpha: Double) {
+        backgroundColor = backgroundColor?.withAlphaComponent(alpha)
+    }
+    
+    @objc func drag(_ sender: UIPanGestureRecognizer) {
+        let translation = sender.translation(in: self)
+        sender.view!.center = CGPoint(x: sender.view!.center.x + translation.x, y: sender.view!.center.y + translation.y)
+        sender.setTranslation(.zero, in: self)
+        isSelected = false
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard touches.count == 2 else { return }
+        
+        removeFromSuperview()
+    }
+    
+    func coverOpaqueView() {
+        let opaqueView = UIView(frame: self.bounds)
+        addSubview(opaqueView)
+        opaqueView.backgroundColor = UIColor.white.withAlphaComponent(0.5)
     }
 }

--- a/DrawingApp/DrawingApp/Views/Rectangle/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Views/Rectangle/Rectangle.swift
@@ -38,30 +38,11 @@ class Rectangle: UIView, IndexedRectangle {
         super.init(frame: frame)
     }
     
-    func setCopiedView(rect: Rectangle) {
+    func setCopiedView(rect: Rectangle?) {
         copiedView = rect
     }
     
     func setAlpha(_ alpha: Double) {
         backgroundColor = backgroundColor?.withAlphaComponent(alpha)
-    }
-    
-    @objc func drag(_ sender: UIPanGestureRecognizer) {
-        let translation = sender.translation(in: self)
-        sender.view!.center = CGPoint(x: sender.view!.center.x + translation.x, y: sender.view!.center.y + translation.y)
-        sender.setTranslation(.zero, in: self)
-        isSelected = false
-    }
-    
-    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard touches.count == 2 else { return }
-        
-        removeFromSuperview()
-    }
-    
-    func coverOpaqueView() {
-        let opaqueView = UIView(frame: self.bounds)
-        addSubview(opaqueView)
-        opaqueView.backgroundColor = UIColor.white.withAlphaComponent(0.5)
     }
 }

--- a/README.md
+++ b/README.md
@@ -360,3 +360,17 @@ var notificationInfo = [
 ### 결과 화면
 
 <img src="DrawingApp/IMAGES/Step4_Result4.jpg" alt="Step4_Result4" width="500" />
+
+---
+
+## Step 5 - Touch And Drag
+
+### 목표
+
+* UIGestureRecognizer를 정리하고 실제 구현합니다.
+* UIGestureRecognizer 클래스가 어떻게 구체 클래스로 타입을 구체화시키는지 확인해본다.
+
+### 구현 전략
+
+* 각 이벤트에 대해 처리되는 기능을 타입으로 표현할 수 있도록 뷰를 확장해본다.
+* 뷰에서 제스쳐 이벤트 발생 -> 뷰 컨트롤러 델리게이트 콜백 -> 모델 변화 -> 모델에서 뷰 컨트롤러에 뷰 변화 요청 -> 뷰 컨트롤러에서 뷰 변화 하는 MVC의 흐름을 따라 개발을 진행한다.


### PR DESCRIPTION
# 자세한 디버깅 이전에 PR을 보내는 점 양해 부탁드립니다.

원래라면 디버깅이 완료된 이후에 완벽히 작동한다는 확신이 생기면 PR을 요청드렸겠지만, 이대로는 아래의 이유로 인해 학습에 지장이 될까봐 미리 PR을 보내게 된 점 양해 부탁드립니다.

1. 기능구현을 위해 낸 아이디어가 구조 상 이상이 없는지 확인 후 디버깅과 추가수정을 진행하는 것이 좋을 것 같다고 판단하였습니다.
2. 리뷰의 텀이 너무 길어질 것 같았습니다. 하루에 하나를 보내는 것을 목표로 하고 작업했지만, 이번 제스쳐 작업은 많은 시간을 소요하게 되었습니다.

현재 기능작동은 모두 잘 진행되고 있으나, 추가 작업을 진행할 부분은 다음과 같습니다.

* 팬 제스쳐를 할 때 드래그 할 수 있는 최대 영역을 지정하는 작업을 진행할 예정입니다.

## 작업 목록

* 터치 이벤트 하나를 더 추가하여 두 손가락으로 터치를 하면 임시 뷰가 만들어집니다.
* 임시뷰가 만들어진 상태에서 팬 제스쳐를 이용하여 이동이 가능하도록 하였습니다.

## 기능 구현 방법

Rectangle은 선택이 된 상태가 되면, 두 손가락을 이용해 임시 뷰가 될 수 있습니다. 그리고 팬 제스쳐도 추가하여 드래그도 가능하게 합니다.
두 손가락을 이용한 제스쳐가 실행되면, UIGestureRecognizerDelegate 메소드를 이용해 Rectangle이 임시뷰가 되고, 복사된 뷰는 Rectangle의 밑에 추가합니다.
팬 제스쳐로 드래그를 한 뒤 드래그가 끝나면 기존의 Rectangle은 사라지고, 복사된 뷰가 Rectangle을 대신합니다.

![step5_idea](https://user-images.githubusercontent.com/65931336/159164002-fea53626-4bd4-437d-b317-55f0cc8f9e83.jpeg)