### PR TITLE
[Jed] Step 3-6 : ViewController 분리, 사각형 뷰 위치 및 크기 속성 변경 기능 추가

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		B5C4717927E318C000E6D827 /* RectanglePoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C4717827E318C000E6D827 /* RectanglePoint.swift */; };
 		B5C4717B27E318C700E6D827 /* RectangleAlpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C4717A27E318C700E6D827 /* RectangleAlpha.swift */; };
 		B5C4717D27E3224C00E6D827 /* RectangleColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C4717C27E3224C00E6D827 /* RectangleColor.swift */; };
+		B5C4718627E45F4900E6D827 /* StylerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C4718527E45F4900E6D827 /* StylerViewController.swift */; };
+		B5C4718927E4D1E900E6D827 /* StylerViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C4718827E4D1E900E6D827 /* StylerViewControllerDelegate.swift */; };
 		B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */; };
 		B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BA127CDC29E0016E628 /* SceneDelegate.swift */; };
 		B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E73BA327CDC29E0016E628 /* ViewController.swift */; };
@@ -63,6 +65,8 @@
 		B5C4717827E318C000E6D827 /* RectanglePoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectanglePoint.swift; sourceTree = "<group>"; };
 		B5C4717A27E318C700E6D827 /* RectangleAlpha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleAlpha.swift; sourceTree = "<group>"; };
 		B5C4717C27E3224C00E6D827 /* RectangleColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleColor.swift; sourceTree = "<group>"; };
+		B5C4718527E45F4900E6D827 /* StylerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylerViewController.swift; sourceTree = "<group>"; };
+		B5C4718827E4D1E900E6D827 /* StylerViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylerViewControllerDelegate.swift; sourceTree = "<group>"; };
 		B5E73B9C27CDC29E0016E628 /* DrawingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrawingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5E73B9F27CDC29E0016E628 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B5E73BA127CDC29E0016E628 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -149,6 +153,14 @@
 			path = DelegateProtocols;
 			sourceTree = "<group>";
 		};
+		B5C4718727E4D1D300E6D827 /* DelegateProtocols */ = {
+			isa = PBXGroup;
+			children = (
+				B5C4718827E4D1E900E6D827 /* StylerViewControllerDelegate.swift */,
+			);
+			path = DelegateProtocols;
+			sourceTree = "<group>";
+		};
 		B5E73B9327CDC29D0016E628 = {
 			isa = PBXGroup;
 			children = (
@@ -209,7 +221,9 @@
 		B5E73BBD27D07CAA0016E628 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
+				B5C4718727E4D1D300E6D827 /* DelegateProtocols */,
 				B5E73BA327CDC29E0016E628 /* ViewController.swift */,
+				B5C4718527E45F4900E6D827 /* StylerViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -354,7 +368,9 @@
 				B5E73BA427CDC29E0016E628 /* ViewController.swift in Sources */,
 				B58D8E5C27DCC71B0018B3E2 /* Rectangle.swift in Sources */,
 				B5C4717727E318B800E6D827 /* RectangleSize.swift in Sources */,
+				B5C4718927E4D1E900E6D827 /* StylerViewControllerDelegate.swift in Sources */,
 				B5E73BA027CDC29E0016E628 /* AppDelegate.swift in Sources */,
+				B5C4718627E45F4900E6D827 /* StylerViewController.swift in Sources */,
 				B5E73BA227CDC29E0016E628 /* SceneDelegate.swift in Sources */,
 				B5E73BBC27CF457B0016E628 /* Plane.swift in Sources */,
 				B5C4716F27E3112F00E6D827 /* CustomImageApplicable.swift in Sources */,

--- a/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
+++ b/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="ipad10_9rounded" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,7 +11,7 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="DrawingApp" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="DrawingApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="1180" height="820"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/DrawingApp/DrawingApp/Controller/DelegateProtocols/StylerViewControllerDelegate.swift
+++ b/DrawingApp/DrawingApp/Controller/DelegateProtocols/StylerViewControllerDelegate.swift
@@ -5,4 +5,6 @@ protocol StylerViewControllerDelegate: AnyObject{
     func updatingSelectedRectangleAlphaRequested(opacity: Int)
     func updatingSelectedRectanglePointXRequested(increase: Bool)
     func updatingSelectedRectanglePointYRequested(increase: Bool)
+    func updatingSelectedRectangleWidthRequested(increase: Bool)
+    func updatingSelectedRectangleHeightRequested(increase: Bool)
 }

--- a/DrawingApp/DrawingApp/Controller/DelegateProtocols/StylerViewControllerDelegate.swift
+++ b/DrawingApp/DrawingApp/Controller/DelegateProtocols/StylerViewControllerDelegate.swift
@@ -3,4 +3,6 @@ import Foundation
 protocol StylerViewControllerDelegate: AnyObject{
     func updatingSelectedRectangleColorRequested()
     func updatingSelectedRectangleAlphaRequested(opacity: Int)
+    func updatingSelectedRectanglePointXRequested(increase: Bool)
+    func updatingSelectedRectanglePointYRequested(increase: Bool)
 }

--- a/DrawingApp/DrawingApp/Controller/DelegateProtocols/StylerViewControllerDelegate.swift
+++ b/DrawingApp/DrawingApp/Controller/DelegateProtocols/StylerViewControllerDelegate.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol StylerViewControllerDelegate: AnyObject{
+    func updatingSelectedRectangleColorRequested()
+    func updatingSelectedRectangleAlphaRequested(opacity: Int)
+}

--- a/DrawingApp/DrawingApp/Controller/StylerViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/StylerViewController.swift
@@ -22,11 +22,13 @@ class StylerViewController: UIViewController{
     }
     
     func updateSelectedRectangleInfo(rectangle: RectangleApplicable){
+        guard let stylerView = self.view as? StylerView else { return }
         if rectangle is RandomColorApplicable{
             self.updateColorRectangleInfo(rectangle: rectangle)
         }else{
             self.updateImageRectangleInfo(rectangle: rectangle)
         }
+        stylerView.updateRectanglePointInfo(rectangle: rectangle)
     }
     
     func clearSelectedRectangleInfo(){

--- a/DrawingApp/DrawingApp/Controller/StylerViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/StylerViewController.swift
@@ -72,32 +72,26 @@ class StylerViewController: UIViewController{
 extension StylerViewController: StylerViewDelegate{
     
     func updatingSelectedRectangleColorRequested(){
-        guard let delegate = self.delegate else { return }
-        delegate.updatingSelectedRectangleColorRequested()
+        self.delegate?.updatingSelectedRectangleColorRequested()
     }
     
     func updatingSelectedRectangleAlphaRequested(opacity: Int){
-        guard let delegate = self.delegate else { return }
-        delegate.updatingSelectedRectangleAlphaRequested(opacity: opacity)
+        self.delegate?.updatingSelectedRectangleAlphaRequested(opacity: opacity)
     }
     
     func updatingSelectedRectanglePointXRequested(increase: Bool){
-        guard let delegate = self.delegate else { return }
-        delegate.updatingSelectedRectanglePointXRequested(increase: increase)
+        self.delegate?.updatingSelectedRectanglePointXRequested(increase: increase)
     }
     
     func updatingSelectedRectanglePointYRequested(increase: Bool){
-        guard let delegate = self.delegate else { return }
-        delegate.updatingSelectedRectanglePointYRequested(increase: increase)
+        self.delegate?.updatingSelectedRectanglePointYRequested(increase: increase)
     }
     
     func updatingSelectedRectangleWidthRequested(increase: Bool) {
-        guard let delegate = self.delegate else { return }
-        delegate.updatingSelectedRectangleWidthRequested(increase: increase)
+        self.delegate?.updatingSelectedRectangleWidthRequested(increase: increase)
     }
     
     func updatingSelectedRectangleHeightRequested(increase: Bool) {
-        guard let delegate = self.delegate else { return }
-        delegate.updatingSelectedRectangleHeightRequested(increase: increase)
+        self.delegate?.updatingSelectedRectangleHeightRequested(increase: increase)
     }
 }

--- a/DrawingApp/DrawingApp/Controller/StylerViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/StylerViewController.swift
@@ -29,6 +29,7 @@ class StylerViewController: UIViewController{
             self.updateImageRectangleInfo(rectangle: rectangle)
         }
         stylerView.updateRectanglePointInfo(rectangle: rectangle)
+        stylerView.updateRectangleSizeInfo(rectangle: rectangle)
     }
     
     func clearSelectedRectangleInfo(){
@@ -61,6 +62,11 @@ class StylerViewController: UIViewController{
         guard let stylerView = self.view as? StylerView else { return }
         stylerView.updateSelectedRectangleViewPointInfo(point: point)
     }
+    
+    func updateSelectedRectangleViewSizeInfo(size: CGSize){
+        guard let stylerView = self.view as? StylerView else { return }
+        stylerView.updateSelectedRectangleViewSizeInfo(size: size)
+    }
 }
 
 extension StylerViewController: StylerViewDelegate{
@@ -83,5 +89,15 @@ extension StylerViewController: StylerViewDelegate{
     func updatingSelectedRectanglePointYRequested(increase: Bool){
         guard let delegate = self.delegate else { return }
         delegate.updatingSelectedRectanglePointYRequested(increase: increase)
+    }
+    
+    func updatingSelectedRectangleWidthRequested(increase: Bool) {
+        guard let delegate = self.delegate else { return }
+        delegate.updatingSelectedRectangleWidthRequested(increase: increase)
+    }
+    
+    func updatingSelectedRectangleHeightRequested(increase: Bool) {
+        guard let delegate = self.delegate else { return }
+        delegate.updatingSelectedRectangleHeightRequested(increase: increase)
     }
 }

--- a/DrawingApp/DrawingApp/Controller/StylerViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/StylerViewController.swift
@@ -50,12 +50,10 @@ class StylerViewController: UIViewController{
         stylerView.updateImageRectangleInfo(opacity: rectangle.alpha.opacity.rawValue)
     }
     
-    
     func updateSelectedRectangleViewColorInfo(newColor: UIColor, newHexString: String){
         guard let stylerView = self.view as? StylerView else { return }
         stylerView.updateSelectedRectangleViewColorInfo(newColor: newColor, newHexString: newHexString)
     }
-    
 }
 
 extension StylerViewController: StylerViewDelegate{
@@ -69,5 +67,4 @@ extension StylerViewController: StylerViewDelegate{
         guard let delegate = self.delegate else { return }
         delegate.updatingSelectedRectangleAlphaRequested(opacity: opacity)
     }
-
 }

--- a/DrawingApp/DrawingApp/Controller/StylerViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/StylerViewController.swift
@@ -1,0 +1,73 @@
+import Foundation
+import UIKit
+
+class StylerViewController: UIViewController{
+    
+    weak var delegate: StylerViewControllerDelegate?
+    
+    override func didMove(toParent parent: UIViewController?) {
+        setStylerView()
+    }
+    
+    private func setStylerView(){
+        guard let parent = self.parent else { return }
+        guard let canvasView = parent.view.subviews[0] as? CanvasView else { return }
+        let frame = CGRect(x: canvasView.frame.width,
+                           y: parent.view.frame.minY,
+                           width: parent.view.frame.width - canvasView.frame.width,
+                           height: parent.view.frame.height)
+        let stylerView = StylerView(frame: frame, backgroundColor: .white)
+        stylerView.delegate = self
+        self.view = stylerView
+    }
+    
+    func updateSelectedRectangleInfo(rectangle: RectangleApplicable){
+        if rectangle is RandomColorApplicable{
+            self.updateColorRectangleInfo(rectangle: rectangle)
+        }else{
+            self.updateImageRectangleInfo(rectangle: rectangle)
+        }
+    }
+    
+    func clearSelectedRectangleInfo(){
+        guard let stylerView = self.view as? StylerView else { return }
+        stylerView.clearSelectedRectangleInfo()
+    }
+    
+    private func updateColorRectangleInfo(rectangle: RectangleApplicable){
+        guard let stylerView = self.view as? StylerView else { return }
+        guard let rectangle = rectangle as? RectangleApplicable & RandomColorApplicable else { return }
+        let r = rectangle.backgroundColor.r
+        let g = rectangle.backgroundColor.g
+        let b = rectangle.backgroundColor.b
+        let opacity = rectangle.alpha.opacity.rawValue
+        let hexString = "#\(String(Int(r*255), radix: 16))\(String(Int(g*255), radix: 16))\(String(Int(b*255), radix: 16))"
+        stylerView.updateColorRectangleInfo(r: r, g: g, b: b, opacity: opacity, hexString: hexString)
+    }
+    
+    private func updateImageRectangleInfo(rectangle: RectangleApplicable){
+        guard let stylerView = self.view as? StylerView else { return }
+        stylerView.updateImageRectangleInfo(opacity: rectangle.alpha.opacity.rawValue)
+    }
+    
+    
+    func updateSelectedRectangleViewColorInfo(newColor: UIColor, newHexString: String){
+        guard let stylerView = self.view as? StylerView else { return }
+        stylerView.updateSelectedRectangleViewColorInfo(newColor: newColor, newHexString: newHexString)
+    }
+    
+}
+
+extension StylerViewController: StylerViewDelegate{
+    
+    func updatingSelectedRectangleColorRequested(){
+        guard let delegate = self.delegate else { return }
+        delegate.updatingSelectedRectangleColorRequested()
+    }
+    
+    func updatingSelectedRectangleAlphaRequested(opacity: Int){
+        guard let delegate = self.delegate else { return }
+        delegate.updatingSelectedRectangleAlphaRequested(opacity: opacity)
+    }
+
+}

--- a/DrawingApp/DrawingApp/Controller/StylerViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/StylerViewController.swift
@@ -56,6 +56,11 @@ class StylerViewController: UIViewController{
         guard let stylerView = self.view as? StylerView else { return }
         stylerView.updateSelectedRectangleViewColorInfo(newColor: newColor, newHexString: newHexString)
     }
+    
+    func updateSelectedRectangleViewPointInfo(point: CGPoint){
+        guard let stylerView = self.view as? StylerView else { return }
+        stylerView.updateSelectedRectangleViewPointInfo(point: point)
+    }
 }
 
 extension StylerViewController: StylerViewDelegate{
@@ -68,5 +73,15 @@ extension StylerViewController: StylerViewDelegate{
     func updatingSelectedRectangleAlphaRequested(opacity: Int){
         guard let delegate = self.delegate else { return }
         delegate.updatingSelectedRectangleAlphaRequested(opacity: opacity)
+    }
+    
+    func updatingSelectedRectanglePointXRequested(increase: Bool){
+        guard let delegate = self.delegate else { return }
+        delegate.updatingSelectedRectanglePointXRequested(increase: increase)
+    }
+    
+    func updatingSelectedRectanglePointYRequested(increase: Bool){
+        guard let delegate = self.delegate else { return }
+        delegate.updatingSelectedRectanglePointYRequested(increase: increase)
     }
 }

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -125,8 +125,10 @@ class ViewController: UIViewController{
     
     @objc func updateSelectedRectangleViewPoint(_ notification: Notification){
         guard let canvasView = self.canvasView else { return }
+        guard let stylerViewController = self.stylerViewController else { return }
         guard let selectedRectangle = notification.userInfo?[Plane.UserInfoKey.rectanglePointUpdated] as? RectangleApplicable else { return }
         canvasView.updateSelectedRectanglePoint(point:CGPoint(x: selectedRectangle.point.x, y: selectedRectangle.point.y))
+        stylerViewController.updateSelectedRectangleViewPointInfo(point:CGPoint(x: selectedRectangle.point.x, y: selectedRectangle.point.y))
     }
 
 }
@@ -230,5 +232,13 @@ extension ViewController: StylerViewControllerDelegate{
     
     func updatingSelectedRectangleAlphaRequested(opacity: Int) {
         self.plane.updateRectangleAlpha(opacity: opacity)
+    }
+    
+    func updatingSelectedRectanglePointXRequested(increase: Bool) {
+        self.plane.updateRectanglePointX(increase: increase)
+    }
+    
+    func updatingSelectedRectanglePointYRequested(increase: Bool) {
+        self.plane.updateRectanglePointY(increase: increase)
     }
 }

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -30,6 +30,7 @@ class ViewController: UIViewController{
         NotificationCenter.default.addObserver(self, selector: #selector(updateSelectedRecntalgeViewColor(_:)), name: Plane.NotificationName.rectangleColorUpdated , object: self.plane)
         NotificationCenter.default.addObserver(self, selector: #selector(updateSelectedRectangleViewAlpha(_:)), name: Plane.NotificationName.rectangleAlphaUpdated, object: self.plane)
         NotificationCenter.default.addObserver(self, selector: #selector(updateSelectedRectangleViewPoint(_:)), name: Plane.NotificationName.rectanglePointUpdated, object: self.plane)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateSelectedRectangleViewSize(_:)), name: Plane.NotificationName.rectangleSizeUpdated, object: self.plane)
     }
     
     private func setGestureRecognizer(){
@@ -130,6 +131,15 @@ class ViewController: UIViewController{
         canvasView.updateSelectedRectanglePoint(point:CGPoint(x: selectedRectangle.point.x, y: selectedRectangle.point.y))
         stylerViewController.updateSelectedRectangleViewPointInfo(point:CGPoint(x: selectedRectangle.point.x, y: selectedRectangle.point.y))
     }
+    
+    @objc func updateSelectedRectangleViewSize(_ notification: Notification){
+        guard let canvasView = self.canvasView else { return }
+        guard let stylerViewController = self.stylerViewController else { return }
+        guard let selectedRectangle = notification.userInfo?[Plane.UserInfoKey.rectangleSizeUpdated] as? RectangleApplicable else { return }
+        let newSize = CGSize(width: selectedRectangle.size.width, height: selectedRectangle.size.height)
+        canvasView.updateSelectedRectangleSize(size: newSize)
+        stylerViewController.updateSelectedRectangleViewSizeInfo(size: newSize)
+    }
 
 }
 
@@ -225,6 +235,7 @@ extension ViewController: CanvasViewDelegate, UIImagePickerControllerDelegate, U
 }
 
 extension ViewController: StylerViewControllerDelegate{
+    
     func updatingSelectedRectangleColorRequested() {
         let newColor = RectangleFactory.createRandomColor()
         self.plane.updateRectangleColor(newColor: newColor)
@@ -241,4 +252,13 @@ extension ViewController: StylerViewControllerDelegate{
     func updatingSelectedRectanglePointYRequested(increase: Bool) {
         self.plane.updateRectanglePointY(increase: increase)
     }
+    
+    func updatingSelectedRectangleWidthRequested(increase: Bool) {
+        self.plane.updateRectangleWidth(increase: increase)
+    }
+    
+    func updatingSelectedRectangleHeightRequested(increase: Bool) {
+        self.plane.updateRectangleHeight(increase: increase)
+    }
+    
 }

--- a/DrawingApp/DrawingApp/Controller/ViewController.swift
+++ b/DrawingApp/DrawingApp/Controller/ViewController.swift
@@ -8,7 +8,7 @@ class ViewController: UIViewController{
     private var stylerView: StylerView?
     private var plane: Plane = Plane()
     private var rectangleDictionary:[Rectangle:UIView] = [:]
-    private var temporarySelectedRectangleView: UIView?
+    private var temporarilySelectedRectangleView: UIView?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -79,7 +79,6 @@ class ViewController: UIViewController{
            let rectangle = rectangle as? Rectangle{
             self.rectangleDictionary[rectangle] = rectangleView
             canvasView.insertSubview(rectangleView, belowSubview: canvasView.generatingButton)
-            print(canvasView.subviews)
         }
         
     }
@@ -181,26 +180,26 @@ extension ViewController: UIGestureRecognizerDelegate{
     private func startPanGesture(location: CGPoint){
         guard let canvasView = self.canvasView else { return }
         guard let rectangle: RectangleApplicable = self.plane.findMatchingRectangleModel(x: location.x, y: location.y) else { return }
-        if let temporarySelectedRectangleView = RectangleViewFactory.createRectangleView(rectangle: rectangle){
-            self.temporarySelectedRectangleView = temporarySelectedRectangleView
-            canvasView.addSubview(temporarySelectedRectangleView)
+        if let temporarilySelectedRectangleView = RectangleViewFactory.createRectangleView(rectangle: rectangle){
+            self.temporarilySelectedRectangleView = temporarilySelectedRectangleView
+            canvasView.addSubview(temporarilySelectedRectangleView)
         }
 
     }
     
     private func changePanGesture(location: CGPoint){
-        if let temporarySelectedRectangleView = self.temporarySelectedRectangleView{
-            temporarySelectedRectangleView.frame.origin = CGPoint(x: location.x, y: location.y)
-            temporarySelectedRectangleView.alpha = 0.5
+        if let temporarilySelectedRectangleView = self.temporarilySelectedRectangleView{
+            temporarilySelectedRectangleView.frame.origin = CGPoint(x: location.x, y: location.y)
+            temporarilySelectedRectangleView.alpha = 0.5
         }
     }
     
     private func endPanGesture(location: CGPoint){
-        if let temporarySelectedRectangleView = self.temporarySelectedRectangleView{
-            self.plane.updateSelectedRectanglePoint(x: temporarySelectedRectangleView.frame.origin.x, y: temporarySelectedRectangleView.frame.origin.y)
-            temporarySelectedRectangleView.removeFromSuperview()
+        if let temporarilySelectedRectangleView = self.temporarilySelectedRectangleView{
+            self.plane.updateSelectedRectanglePoint(x: temporarilySelectedRectangleView.frame.origin.x, y: temporarilySelectedRectangleView.frame.origin.y)
+            temporarilySelectedRectangleView.removeFromSuperview()
         }
-        self.temporarySelectedRectangleView = nil
+        self.temporarilySelectedRectangleView = nil
     }
     
 }

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -9,6 +9,7 @@ class Plane:CustomStringConvertible{
         case rectangleColorUpdated = "rectangleColorUpdated"
         case rectangleAlphaUpdated = "rectangleAlphaUpdated"
         case rectanglePointUpdated = "rectanglePointUpdated"
+        case rectangleSizeUpdated = "rectangleSizeUpdated"
     }
     
     struct NotificationName{
@@ -18,6 +19,7 @@ class Plane:CustomStringConvertible{
         static let rectangleColorUpdated = Notification.Name("rectangleColorUpdated")
         static let rectangleAlphaUpdated = Notification.Name("rectangleAlphaUpdated")
         static let rectanglePointUpdated = Notification.Name("rectanglePointUpdated")
+        static let rectangleSizeUpdated = Notification.Name("rectangleSizeUpdated")
     }
     
     private var rectangles:[RectangleApplicable] = []
@@ -101,5 +103,21 @@ class Plane:CustomStringConvertible{
         let value: Double = increase == true ? 5.0 : -5.0
         selectedRectangle.updatePoint(x: selectedRectangle.point.x, y: selectedRectangle.point.y+value)
         NotificationCenter.default.post(name: NotificationName.rectanglePointUpdated, object: self, userInfo: [UserInfoKey.rectanglePointUpdated:selectedRectangle])
+    }
+    
+    func updateRectangleWidth(increase: Bool){
+        guard let selectedRectangleIndex = self.selectedRectangleIndex else { return }
+        let selectedRectangle = self.rectangles[selectedRectangleIndex]
+        let value: Double = increase == true ? 5.0 : -5.0
+        selectedRectangle.updateSize(width: selectedRectangle.size.width + value, height: selectedRectangle.size.height)
+        NotificationCenter.default.post(name: NotificationName.rectangleSizeUpdated, object: self, userInfo: [UserInfoKey.rectangleSizeUpdated:selectedRectangle])
+    }
+    
+    func updateRectangleHeight(increase: Bool){
+        guard let selectedRectangleIndex = self.selectedRectangleIndex else { return }
+        let selectedRectangle = self.rectangles[selectedRectangleIndex]
+        let value: Double = increase == true ? 5.0 : -5.0
+        selectedRectangle.updateSize(width: selectedRectangle.size.width, height: selectedRectangle.size.height+value)
+        NotificationCenter.default.post(name: NotificationName.rectangleSizeUpdated, object: self, userInfo: [UserInfoKey.rectangleSizeUpdated:selectedRectangle])
     }
 }

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -86,4 +86,20 @@ class Plane:CustomStringConvertible{
         selectedRectangle.updatePoint(x: x, y: y)
         NotificationCenter.default.post(name: NotificationName.rectanglePointUpdated, object: self, userInfo: [UserInfoKey.rectanglePointUpdated:selectedRectangle])
     }
+    
+    func updateRectanglePointX(increase: Bool){
+        guard let selectedRectangleIndex = self.selectedRectangleIndex else { return }
+        let selectedRectangle = self.rectangles[selectedRectangleIndex]
+        let value: Double = increase == true ? 5.0 : -5.0
+        selectedRectangle.updatePoint(x: selectedRectangle.point.x+value, y: selectedRectangle.point.y)
+        NotificationCenter.default.post(name: NotificationName.rectanglePointUpdated, object: self, userInfo: [UserInfoKey.rectanglePointUpdated:selectedRectangle])
+    }
+    
+    func updateRectanglePointY(increase: Bool){
+        guard let selectedRectangleIndex = self.selectedRectangleIndex else { return }
+        let selectedRectangle = self.rectangles[selectedRectangleIndex]
+        let value: Double = increase == true ? 5.0 : -5.0
+        selectedRectangle.updatePoint(x: selectedRectangle.point.x, y: selectedRectangle.point.y+value)
+        NotificationCenter.default.post(name: NotificationName.rectanglePointUpdated, object: self, userInfo: [UserInfoKey.rectanglePointUpdated:selectedRectangle])
+    }
 }

--- a/DrawingApp/DrawingApp/Model/Protocols/RectangleApplicable.swift
+++ b/DrawingApp/DrawingApp/Model/Protocols/RectangleApplicable.swift
@@ -9,5 +9,6 @@ protocol RectangleApplicable: CustomStringConvertible{
     
     func updateAlpha(opacity: Int)
     func updatePoint(x: Double, y: Double)
+    func updateSize(width: Double, height: Double)
     func isPointInsideTheRectangleRange(x: Double, y: Double)->Bool
 }

--- a/DrawingApp/DrawingApp/Model/Rectangle.swift
+++ b/DrawingApp/DrawingApp/Model/Rectangle.swift
@@ -26,6 +26,18 @@ class Rectangle: RectangleApplicable, CustomStringConvertible{
         self.point.y = y
     }
     
+    func updateSize(width: Double, height: Double) {
+        self.size.width = adjustRange(width)
+        self.size.height = adjustRange(height)
+        
+        func adjustRange(_ value: Double)->Double{
+            if(value<=0){
+                return Double(1)
+            }
+            return value
+        }
+    }
+    
     func isPointInsideTheRectangleRange(x: Double, y: Double) -> Bool {
         let minX = self.point.x
         let minY = self.point.y
@@ -37,7 +49,6 @@ class Rectangle: RectangleApplicable, CustomStringConvertible{
         
         return false
     }
-    
 }
 
 extension Rectangle: Hashable{

--- a/DrawingApp/DrawingApp/View/CanvasView.swift
+++ b/DrawingApp/DrawingApp/View/CanvasView.swift
@@ -51,6 +51,12 @@ class CanvasView: UIView{
         selectedRectangleView.frame.origin = point
     }
     
+    func updateSelectedRectangleSize(size: CGSize){
+        guard let selectedRectangleView = selectedRectangleView else { return }
+        selectedRectangleView.frame.size.width = size.width
+        selectedRectangleView.frame.size.height = size.height
+    }
+    
     private func setGeneratingButton(){
         let buttonWidth = self.frame.width*0.15
         let buttonHeight = self.frame.height*0.15

--- a/DrawingApp/DrawingApp/View/DelegateProtocols/StylerViewDelegate.swift
+++ b/DrawingApp/DrawingApp/View/DelegateProtocols/StylerViewDelegate.swift
@@ -5,4 +5,6 @@ import UIKit
 protocol StylerViewDelegate: AnyObject{
     func updatingSelectedRectangleAlphaRequested(opacity: Int)
     func updatingSelectedRectangleColorRequested()
+    func updatingSelectedRectanglePointXRequested(increase: Bool)
+    func updatingSelectedRectanglePointYRequested(increase: Bool)
 }

--- a/DrawingApp/DrawingApp/View/DelegateProtocols/StylerViewDelegate.swift
+++ b/DrawingApp/DrawingApp/View/DelegateProtocols/StylerViewDelegate.swift
@@ -7,4 +7,6 @@ protocol StylerViewDelegate: AnyObject{
     func updatingSelectedRectangleColorRequested()
     func updatingSelectedRectanglePointXRequested(increase: Bool)
     func updatingSelectedRectanglePointYRequested(increase: Bool)
+    func updatingSelectedRectangleWidthRequested(increase: Bool)
+    func updatingSelectedRectangleHeightRequested(increase: Bool)
 }

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -244,23 +244,17 @@ class StylerView: UIView{
     
     func setRectangleSizeChangeAction(){
         self.rectangleWidthIncreaseButton.addAction(UIAction(title: ""){_ in
-            guard let delegate = self.delegate else { return }
-            delegate.updatingSelectedRectangleWidthRequested(increase: true)
+            self.delegate?.updatingSelectedRectangleWidthRequested(increase: true)
         }, for: .touchDown)
         self.rectangleWidthDecreaseButton.addAction(UIAction(title: ""){_ in
-            guard let delegate = self.delegate else { return }
-            delegate.updatingSelectedRectangleWidthRequested(increase: false)
+            self.delegate?.updatingSelectedRectangleWidthRequested(increase: false)
         }, for: .touchDown)
         self.rectangleHeightIncreaseButton.addAction(UIAction(title: ""){_ in
-            guard let delegate = self.delegate else { return }
-            delegate.updatingSelectedRectangleHeightRequested(increase: true)
+            self.delegate?.updatingSelectedRectangleHeightRequested(increase: true)
         }, for: .touchDown)
         self.rectangleHeightDecreaseButton.addAction(UIAction(title: ""){_ in
-            guard let delegate = self.delegate else { return }
-            delegate.updatingSelectedRectangleHeightRequested(increase: false)
+            self.delegate?.updatingSelectedRectangleHeightRequested(increase: false)
         }, for: .touchDown)
-        
-        
     }
     
     func updateSelectedRectangleViewColorInfo(newColor: UIColor, newHexString: String){

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -25,6 +25,7 @@ class StylerView: UIView{
         setRectangleAlphaInformationView()
         setAlphaChangeAction()
         setRectanglePointInformationView()
+        setRectanglePointChangeAction()
     }
     
     required init?(coder: NSCoder) {
@@ -156,8 +157,32 @@ class StylerView: UIView{
         self.addSubview(self.rectanglePointYDecreaseButton)
     }
     
+    func setRectanglePointChangeAction(){
+        self.rectanglePointXIncreaseButton.addAction(UIAction(title: ""){_ in
+            guard let delegate = self.delegate else { return }
+            delegate.updatingSelectedRectanglePointXRequested(increase: true)
+        }, for: .touchDown)
+        self.rectanglePointXDecreaseButton.addAction(UIAction(title: ""){_ in
+            guard let delegate = self.delegate else { return }
+            delegate.updatingSelectedRectanglePointXRequested(increase: false)
+        }, for: .touchDown)
+        self.rectanglePointYIncreaseButton.addAction(UIAction(title: ""){_ in
+            guard let delegate = self.delegate else { return }
+            delegate.updatingSelectedRectanglePointYRequested(increase: false)
+        }, for: .touchDown)
+        self.rectanglePointYDecreaseButton.addAction(UIAction(title: ""){_ in
+            guard let delegate = self.delegate else { return }
+            delegate.updatingSelectedRectanglePointYRequested(increase: true)
+        }, for: .touchDown)
+    }
+    
     func updateSelectedRectangleViewColorInfo(newColor: UIColor, newHexString: String){
         self.rectangleColorValueField.backgroundColor = newColor
         self.rectangleColorValueField.setTitle(newHexString, for: .normal)
+    }
+    
+    func updateSelectedRectangleViewPointInfo(point: CGPoint){
+        self.rectanglePointXValueField.text = "\(Int(point.x))"
+        self.rectanglePointYValueField.text = "\(Int(point.y))"
     }
 }

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -16,6 +16,14 @@ class StylerView: UIView{
     private var rectanglePointYValueField: UILabel = UILabel()
     private var rectanglePointYIncreaseButton: UIButton = UIButton()
     private var rectanglePointYDecreaseButton: UIButton = UIButton()
+    private var rectangleWidthLabel: UILabel = UILabel()
+    private var rectangleHeightLabel: UILabel = UILabel()
+    private var rectangleWidthValueField: UILabel = UILabel()
+    private var rectangleHeightValueField: UILabel = UILabel()
+    private var rectangleWidthIncreaseButton: UIButton = UIButton()
+    private var rectangleWidthDecreaseButton: UIButton = UIButton()
+    private var rectangleHeightIncreaseButton: UIButton = UIButton()
+    private var rectangleHeightDecreaseButton: UIButton = UIButton()
     
     init(frame: CGRect, backgroundColor: UIColor){
         super.init(frame: frame)
@@ -26,6 +34,8 @@ class StylerView: UIView{
         setAlphaChangeAction()
         setRectanglePointInformationView()
         setRectanglePointChangeAction()
+        setRectangleSizeInformationView()
+        setRectangleSizeChangeAction()
     }
     
     required init?(coder: NSCoder) {
@@ -54,6 +64,11 @@ class StylerView: UIView{
     func updateRectanglePointInfo(rectangle: RectangleApplicable){
         self.rectanglePointXValueField.text = String(Int(rectangle.point.x))
         self.rectanglePointYValueField.text = String(Int(rectangle.point.y))
+    }
+    
+    func updateRectangleSizeInfo(rectangle: RectangleApplicable){
+        self.rectangleWidthValueField.text = "\(rectangle.size.width)"
+        self.rectangleHeightValueField.text = "\(rectangle.size.height)"
     }
     
     private func setRectangleColorInformationView(){
@@ -176,6 +191,78 @@ class StylerView: UIView{
         }, for: .touchDown)
     }
     
+    func setRectangleSizeInformationView(){
+        self.rectangleWidthLabel.text  = "W: "
+        self.rectangleHeightLabel.text = "H: "
+        self.rectangleWidthIncreaseButton.setTitle("🔼", for: .normal)
+        self.rectangleWidthDecreaseButton.setTitle("🔽", for: .normal)
+        self.rectangleHeightIncreaseButton.setTitle("🔼", for: .normal)
+        self.rectangleHeightDecreaseButton.setTitle("🔽", for: .normal)
+
+        self.rectangleWidthLabel.frame = CGRect(x: self.frame.width*0.1,
+                                                y: self.rectanglePointYLabel.frame.maxY + 40,
+                                                width: 30,
+                                                height: self.frame.height*0.06)
+        self.rectangleWidthValueField.frame = CGRect(x: self.rectangleWidthLabel.frame.minX+30,
+                                                     y: self.rectangleWidthLabel.frame.minY,
+                                                     width: self.frame.width*0.4,
+                                                     height: self.frame.height*0.06)
+        self.rectangleWidthIncreaseButton.frame = CGRect(x: self.rectangleWidthValueField.frame.maxX,
+                                                         y: self.rectangleWidthLabel.frame.minY,
+                                                         width: self.frame.height*0.06,
+                                                         height: self.frame.height*0.03)
+        self.rectangleWidthDecreaseButton.frame = CGRect(x: self.rectangleWidthValueField.frame.maxX,
+                                                         y: self.rectangleWidthIncreaseButton.frame.maxY,
+                                                         width: self.frame.height*0.06,
+                                                         height: self.frame.height*0.03)
+        self.rectangleHeightLabel.frame = CGRect(x: self.frame.width*0.1,
+                                                 y: self.rectangleWidthLabel.frame.maxY + 10,
+                                                 width: 30,
+                                                 height: self.frame.height*0.06)
+        self.rectangleHeightValueField.frame = CGRect(x: self.rectangleHeightLabel.frame.minX+30,
+                                                      y: self.rectangleHeightLabel.frame.minY,
+                                                      width: self.frame.width*0.4,
+                                                      height: self.frame.height*0.06)
+        self.rectangleHeightIncreaseButton.frame = CGRect(x: self.rectangleHeightValueField.frame.maxX,
+                                                          y: self.rectangleHeightLabel.frame.minY,
+                                                          width: self.frame.height*0.06,
+                                                          height: self.frame.height*0.03)
+        self.rectangleHeightDecreaseButton.frame = CGRect(x: self.rectangleHeightValueField.frame.maxX,
+                                                          y: self.rectangleHeightIncreaseButton.frame.maxY,
+                                                          width: self.frame.height*0.06,
+                                                          height: self.frame.height*0.03)
+        
+        self.addSubview(self.rectangleWidthLabel)
+        self.addSubview(self.rectangleWidthValueField)
+        self.addSubview(self.rectangleWidthIncreaseButton)
+        self.addSubview(self.rectangleWidthDecreaseButton)
+        self.addSubview(self.rectangleHeightLabel)
+        self.addSubview(self.rectangleHeightValueField)
+        self.addSubview(self.rectangleHeightIncreaseButton)
+        self.addSubview(self.rectangleHeightDecreaseButton)
+    }
+    
+    func setRectangleSizeChangeAction(){
+        self.rectangleWidthIncreaseButton.addAction(UIAction(title: ""){_ in
+            guard let delegate = self.delegate else { return }
+            delegate.updatingSelectedRectangleWidthRequested(increase: true)
+        }, for: .touchDown)
+        self.rectangleWidthDecreaseButton.addAction(UIAction(title: ""){_ in
+            guard let delegate = self.delegate else { return }
+            delegate.updatingSelectedRectangleWidthRequested(increase: false)
+        }, for: .touchDown)
+        self.rectangleHeightIncreaseButton.addAction(UIAction(title: ""){_ in
+            guard let delegate = self.delegate else { return }
+            delegate.updatingSelectedRectangleHeightRequested(increase: true)
+        }, for: .touchDown)
+        self.rectangleHeightDecreaseButton.addAction(UIAction(title: ""){_ in
+            guard let delegate = self.delegate else { return }
+            delegate.updatingSelectedRectangleHeightRequested(increase: false)
+        }, for: .touchDown)
+        
+        
+    }
+    
     func updateSelectedRectangleViewColorInfo(newColor: UIColor, newHexString: String){
         self.rectangleColorValueField.backgroundColor = newColor
         self.rectangleColorValueField.setTitle(newHexString, for: .normal)
@@ -184,5 +271,10 @@ class StylerView: UIView{
     func updateSelectedRectangleViewPointInfo(point: CGPoint){
         self.rectanglePointXValueField.text = "\(Int(point.x))"
         self.rectanglePointYValueField.text = "\(Int(point.y))"
+    }
+    
+    func updateSelectedRectangleViewSizeInfo(size: CGSize){
+        self.rectangleWidthValueField.text = "\(Int(size.width))"
+        self.rectangleHeightValueField.text = "\(Int(size.height))"
     }
 }

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -67,8 +67,8 @@ class StylerView: UIView{
     }
     
     func updateRectangleSizeInfo(rectangle: RectangleApplicable){
-        self.rectangleWidthValueField.text = "\(rectangle.size.width)"
-        self.rectangleHeightValueField.text = "\(rectangle.size.height)"
+        self.rectangleWidthValueField.text = "\(Int(rectangle.size.width))"
+        self.rectangleHeightValueField.text = "\(Int(rectangle.size.height))"
     }
     
     private func setRectangleColorInformationView(){

--- a/DrawingApp/DrawingApp/View/StylerView.swift
+++ b/DrawingApp/DrawingApp/View/StylerView.swift
@@ -8,6 +8,14 @@ class StylerView: UIView{
     private var rectangleColorValueField: UIButton = UIButton()
     private var rectangleAlphaTextLabel: UILabel = UILabel()
     private var rectangleAlphaSlider: UISlider = UISlider()
+    private var rectanglePointXLabel: UILabel = UILabel()
+    private var rectanglePointXValueField: UILabel = UILabel()
+    private var rectanglePointXIncreaseButton: UIButton = UIButton()
+    private var rectanglePointXDecreaseButton: UIButton = UIButton()
+    private var rectanglePointYLabel: UILabel = UILabel()
+    private var rectanglePointYValueField: UILabel = UILabel()
+    private var rectanglePointYIncreaseButton: UIButton = UIButton()
+    private var rectanglePointYDecreaseButton: UIButton = UIButton()
     
     init(frame: CGRect, backgroundColor: UIColor){
         super.init(frame: frame)
@@ -16,6 +24,7 @@ class StylerView: UIView{
         setColorChangeAction()
         setRectangleAlphaInformationView()
         setAlphaChangeAction()
+        setRectanglePointInformationView()
     }
     
     required init?(coder: NSCoder) {
@@ -39,6 +48,11 @@ class StylerView: UIView{
         self.rectangleColorValueField.setTitle("", for: .normal)
         self.rectangleColorValueField.backgroundColor = .darkGray
         self.rectangleAlphaSlider.value = opacity
+    }
+    
+    func updateRectanglePointInfo(rectangle: RectangleApplicable){
+        self.rectanglePointXValueField.text = String(Int(rectangle.point.x))
+        self.rectanglePointYValueField.text = String(Int(rectangle.point.y))
     }
     
     private func setRectangleColorInformationView(){
@@ -90,9 +104,60 @@ class StylerView: UIView{
         }, for: .valueChanged)
     }
     
+    private func setRectanglePointInformationView(){
+        self.rectanglePointXLabel.text = "X: "
+        self.rectanglePointYLabel.text = "Y: "
+        self.rectanglePointXIncreaseButton.setTitle("🔼", for: .normal)
+        self.rectanglePointXDecreaseButton.setTitle("🔽", for: .normal)
+        self.rectanglePointYIncreaseButton.setTitle("🔼", for: .normal)
+        self.rectanglePointYDecreaseButton.setTitle("🔽", for: .normal)
+        
+        self.rectanglePointXLabel.frame = CGRect(x: self.frame.width*0.1,
+                                                 y: self.rectangleAlphaSlider.frame.maxY + 40,
+                                                 width: 30,
+                                                 height: self.frame.height*0.06)
+        self.rectanglePointXValueField.frame = CGRect(x: self.rectanglePointXLabel.frame.minX+30,
+                                                      y: self.rectanglePointXLabel.frame.minY,
+                                                      width: self.frame.width*0.4,
+                                                      height: self.frame.height*0.06)
+        self.rectanglePointXIncreaseButton.frame = CGRect(x: self.rectanglePointXValueField.frame.maxX,
+                                                          y: self.rectanglePointXLabel.frame.minY,
+                                                          width: self.frame.height*0.06,
+                                                          height: self.frame.height*0.03)
+        self.rectanglePointXDecreaseButton.frame = CGRect(x: self.rectanglePointXValueField.frame.maxX,
+                                                          y: self.rectanglePointXIncreaseButton.frame.maxY,
+                                                          width: self.frame.height*0.06,
+                                                          height: self.frame.height*0.03)
+        self.rectanglePointYLabel.frame = CGRect(x: self.frame.width*0.1,
+                                                 y: self.rectanglePointXLabel.frame.maxY + 10,
+                                                 width: 30,
+                                                 height: self.frame.height*0.06)
+        self.rectanglePointYValueField.frame = CGRect(x: self.rectanglePointYLabel.frame.minX+30,
+                                                      y: self.rectanglePointYLabel.frame.minY,
+                                                      width: self.frame.width*0.4,
+                                                      height: self.frame.height*0.06)
+        self.rectanglePointYIncreaseButton.frame = CGRect(x: self.rectanglePointYValueField.frame.maxX,
+                                                          y: self.rectanglePointYLabel.frame.minY,
+                                                          width: self.frame.height*0.06,
+                                                          height: self.frame.height*0.03)
+        self.rectanglePointYDecreaseButton.frame = CGRect(x: self.rectanglePointYValueField.frame.maxX,
+                                                          y: self.rectanglePointYIncreaseButton.frame.maxY,
+                                                          width: self.frame.height*0.06,
+                                                          height: self.frame.height*0.03)
+
+        
+        self.addSubview(self.rectanglePointXLabel)
+        self.addSubview(self.rectanglePointXValueField)
+        self.addSubview(self.rectanglePointXIncreaseButton)
+        self.addSubview(self.rectanglePointXDecreaseButton)
+        self.addSubview(self.rectanglePointYLabel)
+        self.addSubview(self.rectanglePointYValueField)
+        self.addSubview(self.rectanglePointYIncreaseButton)
+        self.addSubview(self.rectanglePointYDecreaseButton)
+    }
+    
     func updateSelectedRectangleViewColorInfo(newColor: UIColor, newHexString: String){
         self.rectangleColorValueField.backgroundColor = newColor
         self.rectangleColorValueField.setTitle(newHexString, for: .normal)
     }
-    
 }

--- a/DrawingApp/DrawingAppTests/PlaneTest.swift
+++ b/DrawingApp/DrawingAppTests/PlaneTest.swift
@@ -17,7 +17,7 @@ class PlaneTest: XCTestCase {
         let rectangle = Rectangle(id: Id(), size: Size(width: 200, height: 200), point: Point(x: 100, y: 100), alpha: Alpha(opacity: Int.random(in: 0...9)))
         plane.addRectangle(rectangle)
         
-        XCTAssertNotNil(plane[150,150])
-        XCTAssertNil(plane[400,400])
+        XCTAssertNotNil(plane.findMatchingRectangleModel(x:150,y:150))
+        XCTAssertNil(plane.findMatchingRectangleModel(x:400,y:400))
     }
 }


### PR DESCRIPTION
### 작업 내용
- [x] ViewController 분리(StylerViewController 하위 뷰 컨트롤러 추가)
- [x] 선택한 사각형 뷰 위치, 크기 속성 표시
- [x] 선택한 사각형 뷰 위치, 크기 속성 변경   
    
### 고민과 해결
- 단계를 거듭하면서 StylerView 관련 로직이 점점 늘어나는 것 같아서, 기존의 ViewController에서 직접 StylerView를 변경하던 로직들을 따로 StylerViewController이라는 새로운 컨트롤러로 옮긴 후 이를 ViewController의 하위 뷰컨트롤러로 등록했습니다.
```swift
let stylerViewController = StylerViewController()
self.addChild(stylerViewController)
stylerViewController.didMove(toParent: self)
self.view.addSubview(stylerViewController.view)
```
- StylerViewController이 StylerView로부터 받은 입력을 ViewController로 전달하기 위해, StylerViewControllerDelegate를 따로 구현하여 delegate method로 전달하게 했습니다.
    - 이렇게 한 이유는, Plane에 대한 참조를 StylerViewController이 알지 못하도록 하려고 했기 때문입니다.
    - 하지만 현재 이런 방식보다 차라리 동일한 Plane 참조를 ViewController, StylerViewController이 모두 알도록 한 후, Plane에서 특정 모델값의 변경이 일어나면 Notification을 ViewController과 StylerViewController 두 곳에 동시에 전송하는 식으로 다시 수정하는 것을 고려중입니다.
    - 이렇게 생각한 이유는, Plane을 StylerViewController이 모르게 하고 Delegate 패턴을 적용했을 때 StylerViewControllerDelegate 채택으로 인한 부가적인 코드 작성으로 인해, 기존에 의도했던 코드 양 감소가 제대로 충족되지 못했기 때문입니다.
    - 두개의 뷰컨트롤러가 서로를 참조하지 않을 경우에 기존에 의도했던 대로 각 컨트롤러 내부의 코드 양이 유의미하게 줄 것 같습니다.

### 다음 계획
- 이전에 언급하신 아래 코드에 대한 추상화 적용을 지속적으로 적용해볼 계획입니다.
```swift
private var rectangleDictionary:[Rectangle:UIView] = [:]
```
- 현재 사각형 뷰를 터치해서 옮길 때 임시 뷰에 대한 속성값의 변경 상태가 화면에 표시되지 않습니다. 추후 이 부분을 마저 적용하려 합니다.