### PR TITLE
[Ocean] Step2 - RGB자료형 변경 및 UITapGestureRecognizer함수 추가

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		F5C730FD27CC7AB8001B4EFF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5C730FC27CC7AB8001B4EFF /* Assets.xcassets */; };
 		F5C7310027CC7AB8001B4EFF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F5C730FE27CC7AB8001B4EFF /* LaunchScreen.storyboard */; };
 		F5D3D0C027E1A5E200B6DFDF /* Plane.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3D0BF27E1A5E200B6DFDF /* Plane.swift */; };
+		F5D6F2D627E639D50072440B /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D6F2D527E639D50072440B /* Tests.swift */; };
 		F5E3FD2B27E0F4150064883F /* SquareFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E3FD2A27E0F4150064883F /* SquareFactory.swift */; };
 /* End PBXBuildFile section */
 
@@ -33,11 +34,20 @@
 		F5C730FF27CC7AB8001B4EFF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F5C7310127CC7AB8001B4EFF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F5D3D0BF27E1A5E200B6DFDF /* Plane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plane.swift; sourceTree = "<group>"; };
+		F5D6F2D327E639D50072440B /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F5D6F2D527E639D50072440B /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
 		F5E3FD2A27E0F4150064883F /* SquareFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquareFactory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		F5C730ED27CC7AB8001B4EFF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F5D6F2D027E639D50072440B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -63,6 +73,7 @@
 			isa = PBXGroup;
 			children = (
 				F5C730F227CC7AB8001B4EFF /* DrawingApp */,
+				F5D6F2D427E639D50072440B /* Tests */,
 				F5C730F127CC7AB8001B4EFF /* Products */,
 			);
 			sourceTree = "<group>";
@@ -71,6 +82,7 @@
 			isa = PBXGroup;
 			children = (
 				F5C730F027CC7AB8001B4EFF /* DrawingApp.app */,
+				F5D6F2D327E639D50072440B /* Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -88,6 +100,14 @@
 				F5C7310127CC7AB8001B4EFF /* Info.plist */,
 			);
 			path = DrawingApp;
+			sourceTree = "<group>";
+		};
+		F5D6F2D427E639D50072440B /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				F5D6F2D527E639D50072440B /* Tests.swift */,
+			);
+			path = Tests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -110,6 +130,23 @@
 			productReference = F5C730F027CC7AB8001B4EFF /* DrawingApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		F5D6F2D227E639D50072440B /* Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F5D6F2D927E639D50072440B /* Build configuration list for PBXNativeTarget "Tests" */;
+			buildPhases = (
+				F5D6F2CF27E639D50072440B /* Sources */,
+				F5D6F2D027E639D50072440B /* Frameworks */,
+				F5D6F2D127E639D50072440B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Tests;
+			productName = Tests;
+			productReference = F5D6F2D327E639D50072440B /* Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -117,11 +154,14 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
+				LastSwiftUpdateCheck = 1330;
 				LastUpgradeCheck = 1320;
 				TargetAttributes = {
 					F5C730EF27CC7AB8001B4EFF = {
 						CreatedOnToolsVersion = 13.2.1;
+					};
+					F5D6F2D227E639D50072440B = {
+						CreatedOnToolsVersion = 13.3;
 					};
 				};
 			};
@@ -139,6 +179,7 @@
 			projectRoot = "";
 			targets = (
 				F5C730EF27CC7AB8001B4EFF /* DrawingApp */,
+				F5D6F2D227E639D50072440B /* Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -151,6 +192,13 @@
 				F5C7310027CC7AB8001B4EFF /* LaunchScreen.storyboard in Resources */,
 				F5C730FD27CC7AB8001B4EFF /* Assets.xcassets in Resources */,
 				F5C730FB27CC7AB8001B4EFF /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F5D6F2D127E639D50072440B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -169,6 +217,14 @@
 				F5C730F427CC7AB8001B4EFF /* AppDelegate.swift in Sources */,
 				F5D3D0C027E1A5E200B6DFDF /* Plane.swift in Sources */,
 				F5C730F627CC7AB8001B4EFF /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F5D6F2CF27E639D50072440B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F5D6F2D627E639D50072440B /* Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -324,7 +380,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -335,7 +391,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Debug;
 		};
@@ -353,7 +409,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -364,7 +420,41 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 2;
+			};
+			name = Release;
+		};
+		F5D6F2D727E639D50072440B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = H42K746U72;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sun.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F5D6F2D827E639D50072440B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = H42K746U72;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sun.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -385,6 +475,15 @@
 			buildConfigurations = (
 				F5C7310527CC7AB8001B4EFF /* Debug */,
 				F5C7310627CC7AB8001B4EFF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F5D6F2D927E639D50072440B /* Build configuration list for PBXNativeTarget "Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F5D6F2D727E639D50072440B /* Debug */,
+				F5D6F2D827E639D50072440B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/DrawingApp/DrawingApp/AppDelegate.swift
+++ b/DrawingApp/DrawingApp/AppDelegate.swift
@@ -1,36 +1,5 @@
-//
-//  AppDelegate.swift
-//  DrawingApp
-//
-//  Created by 허태양 on 2022/02/28.
-//
-
 import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        return true
-    }
-
-    // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-    }
-
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
-
 }
-

--- a/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
+++ b/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="ipad10_2" orientation="portrait" layout="fullscreen" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="ipad10_9rounded" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -1,10 +1,3 @@
-//
-//  Plane.swift
-//  DrawingApp
-//
-//  Created by 허태양 on 2022/03/16.
-//
-
 import Foundation
 
 struct Plane {

--- a/DrawingApp/DrawingApp/Model/Point.swift
+++ b/DrawingApp/DrawingApp/Model/Point.swift
@@ -1,10 +1,3 @@
-//
-//  Point.swift
-//  DrawingApp
-//
-//  Created by 허태양 on 2022/03/10.
-//
-
 import Foundation
 
 class Point {

--- a/DrawingApp/DrawingApp/Model/Size.swift
+++ b/DrawingApp/DrawingApp/Model/Size.swift
@@ -1,10 +1,3 @@
-//
-//  Size.swift
-//  DrawingApp
-//
-//  Created by 허태양 on 2022/03/10.
-//
-
 import Foundation
 
 class Size {

--- a/DrawingApp/DrawingApp/Model/Square.swift
+++ b/DrawingApp/DrawingApp/Model/Square.swift
@@ -1,10 +1,3 @@
-//
-//  Square.swift
-//  DrawingApp
-//
-//  Created by 허태양 on 2022/03/10.
-//
-
 import Foundation
 
 class Square : CustomStringConvertible {

--- a/DrawingApp/DrawingApp/Model/Square.swift
+++ b/DrawingApp/DrawingApp/Model/Square.swift
@@ -4,37 +4,26 @@ class Square : CustomStringConvertible {
     private var id: String
     private var size: Size
     private var point: Point
-    private var R: Int = 0
-    private var G: Int = 0
-    private var B: Int = 0
-    private var A: Int = 0
+    private var R: UInt8
+    private var G: UInt8
+    private var B: UInt8
+    private var alpha: Int
 
-    init(id: String, size: Size, point: Point, r: Int, g: Int, b: Int, alpha: Int) {
+    init(id: String, size: Size, point: Point, R: UInt8, G: UInt8, B: UInt8, alpha: Int) {
         self.id = id
         self.size = size
         self.point = point
 
-        self.R = setRGBDegree(deg: r)
-        self.G = setRGBDegree(deg: g)
-        self.B = setRGBDegree(deg: b)
+        self.R = R
+        self.G = G
+        self.B = B
         switch alpha {
         case ...0 :
-            self.A = 0
+            self.alpha = 0
         case 10...:
-            self.A = 10
+            self.alpha = 10
         default:
-            self.A = alpha
-        }
-    }
-    
-    func setRGBDegree(deg: Int) -> Int {
-        switch deg {
-        case ...0 :
-            return 0
-        case 256...:
-            return 256
-        default:
-            return deg
+            self.alpha = alpha
         }
     }
     
@@ -50,6 +39,6 @@ class Square : CustomStringConvertible {
     }
     
     var description: String {
-        return "(\(id)), X:\(point.X),Y:\(point.Y), W\(size.Width), H\(size.Height), R:\(R), G:\(G), B:\(B), Alpha: \(A)"
+        return "(\(id)), X:\(point.X),Y:\(point.Y), W\(size.Width), H\(size.Height), R:\(R), G:\(G), B:\(B), alpha: \(alpha)"
     }
 }

--- a/DrawingApp/DrawingApp/Model/SquareFactory.swift
+++ b/DrawingApp/DrawingApp/Model/SquareFactory.swift
@@ -3,8 +3,8 @@ import Foundation
 class SquareFactory {
     let idElement: String = "abcdefghijklmnopqrstuvwxyz0123456789"
 
-    func createSquare(size: Size, point: Point, r: Int, g: Int, b: Int, a: Int) -> Square {
-        return Square(id: getRandomId(), size: size, point: point, r: r, g: g, b: b, alpha: a)
+    func createSquare(size: Size, point: Point, R: UInt8, G: UInt8, B: UInt8, alpha: Int) -> Square {
+        return Square(id: getRandomId(), size: size, point: point, R: UInt8(R), G: UInt8(G), B: UInt8(B), alpha: alpha)
     }
     
     func getRandomId() -> String {

--- a/DrawingApp/DrawingApp/Model/SquareFactory.swift
+++ b/DrawingApp/DrawingApp/Model/SquareFactory.swift
@@ -1,10 +1,3 @@
-//
-//  SquareFactory.swift
-//  DrawingApp
-//
-//  Created by 허태양 on 2022/03/16.
-//
-
 import Foundation
 
 class SquareFactory {

--- a/DrawingApp/DrawingApp/SceneDelegate.swift
+++ b/DrawingApp/DrawingApp/SceneDelegate.swift
@@ -1,52 +1,7 @@
-//
-//  SceneDelegate.swift
-//  DrawingApp
-//
-//  Created by 허태양 on 2022/02/28.
-//
-
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
-    }
-
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-    }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
-    }
-
-    func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
-    }
-
-
 }
-

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -6,6 +6,10 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView(_:)))
+        
+        self.view.addGestureRecognizer(recognizer)
         
         var squareAry : [Square] = []
         
@@ -16,5 +20,9 @@ class ViewController: UIViewController {
         for i in 0..<4 {
             os_log("Rect%@ %@", "\(i)", "\(squareAry[i])")
         }
+    }
+
+    @objc func didTapView(_ sender: UITapGestureRecognizer) {
+        print("did tap: ", sender.location(in: self.view))
     }
 }

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -1,10 +1,3 @@
-//
-//  ViewController.swift
-//  DrawingApp
-//
-//  Created by 허태양 on 2022/02/28.
-//
-
 import UIKit
 import OSLog
 

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -10,7 +10,7 @@ class ViewController: UIViewController {
         var squareAry : [Square] = []
         
         for i in 1..<5 {
-            squareAry.append(factory.createSquare(size: Size(width: Double(i * 100), height: Double(i * 200)), point: Point(X: Double(i * 300), Y: Double(i * 400)), r: i + 10, g: i + 20, b: i + 30, a: 2 * i + 1))
+            squareAry.append(factory.createSquare(size: Size(width: Double(i * 100), height: Double(i * 200)), point: Point(X: Double(i * 300), Y: Double(i * 400)), R: UInt8(i + 10), G: UInt8(i + 20), B: UInt8(i + 30), alpha: 2 * i + 1))
         }
         
         for i in 0..<4 {

--- a/DrawingApp/Tests/Tests.swift
+++ b/DrawingApp/Tests/Tests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import Plane
+@testable import Square
+
+class Tests: XCTestCase {
+
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func testPlane() {
+        // given
+        let plane = Plane()
+        let square1 = Square()
+        
+        // when
+        // addSquare() & totalSquareCount
+        
+        
+        // subscript(index)
+        // subscript(position)
+        
+        
+        // then
+    }
+
+}


### PR DESCRIPTION
### 작업 목록
- 사용하지 않는 코드 및 주석 제거
- 샘플 유닛 테스트 파일 추가
- RGB 자료형 변경
	- RGB의 자료형을 Int에서 UInt8로 변경
- 탭 제스처 인식기를 ViewController에 추가

### 학습 키워드
- UITapGestureRecognizer

## 학습한 내용

### 탭 제스처 인식기
제스처 인식기는 뷰당 한 개만 가질 수 있어, 마지막으로 등록한 제스처 인식기만 쓰인다

### 탭 제스처 인식기 추가하는 방법
- 인터페이스 빌더
    - ViewController.swift에 뷰 생성
    - 스토리보드의 뷰에 드래그하여 연결
    - 스토리보드에서 VC에 탭 제스처 인식기 객체 추가
    - 스토리보드의 탭 제스처 인식기 sent actions 항복에서 ViewController.swift에서 만든 didTapBiew함수와 연결
- 코드로 추가하는 방법
    - ViewDidLoad()단계에서 self.view에 addGestureRecognizer()를 사용하여 UITapGestureRecognizer를 등록
    - UITapGestureRecognizer(target: 뷰 컨트롤러, action:  이벤트 발생시 동작할 함수))

## 고민
1. 프로젝트를 구현하는 과정에서 인터페이스 빌더를 활용할까, 순수하게 코드로만 작성할까?
    - 수업자료와 https://www.toptal.com/ios/ios-user-interfaces-storyboards-vs-nibs-vs-custom-code 참고
    - 배우는 과정에서는 구현범위에 한계가 없는 것이 낫다고 생각하여, 모든 작업을 코드로 작성하기로 했습니다.
2. 올바른 입력값(여기서는 RGBA값)을 처리하는 방법에는 어떤 것이 있을까?
    - 현재까지 생각해낸 방법은 두 가지입니다.
        - 처음부터 올바른 입력값을 넣도록 한다(자료형을 통한 제한. RGB만 가능)
        - 범위를 벗어나는 값을 넣어주면 수정하여 초기화
3. 탭 제스처 인식기를 사용하려면 어떤 과정이 필요할까?
    - 검색을 통해, 인터페이스 빌더로 등록하는 방법과, 코드로 직접 등록하는 방법이 있음을 알게되었습니다.

## 질문
- Square의 RGB에 처음부터 유효한 값을 강제하는 방법을 고민하는 과정에서, RGB의 자료형을 UInt8로 바꾸어 보았습니다. 더 적절한 방법이 있을까요?
    - 나아가, 입력값을 처리하는 다른 방법이 있는지 궁금합니다(고민 2)
- 코드를 정리하는 과정에서 AppDelegate/SceneDelegate의 모든 optional 변수와 함수를 지워도 정상적으로 동작하는 것을 확인했습니다. 그런데 유일하게 window(UIWindow?)변수는 컴파일 에러가 발생하여 지울 수 없었습니다. 변수가 optional임에도 이 변수를 지울 수 없는 이유가 궁금합니다.
- UITapGestureRecognizer를 ViewController의 멤버 변수로 저장하여 등록할 경우, 함수가 정상적으로 호출되지 않는 이유가 궁금합니다.
