### PR TITLE
[Ocean] Step2-2: 사각형 출력 및 선택 기능 추가

### DIFF
--- a/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
+++ b/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="DrawingApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="810" height="1080"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1180" height="820"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/DrawingApp/DrawingApp/Model/Square.swift
+++ b/DrawingApp/DrawingApp/Model/Square.swift
@@ -2,12 +2,12 @@ import Foundation
 
 class Square : CustomStringConvertible {
     private var id: String
-    private var size: Size
-    private var point: Point
-    private var R: UInt8
-    private var G: UInt8
-    private var B: UInt8
-    private var alpha: Int
+    private(set) var size: Size
+    private(set) var point: Point
+    private(set) var R: UInt8
+    private(set) var G: UInt8
+    private(set) var B: UInt8
+    private(set) var alpha: Int
 
     init(id: String, size: Size, point: Point, R: UInt8, G: UInt8, B: UInt8, alpha: Int) {
         self.id = id
@@ -40,5 +40,11 @@ class Square : CustomStringConvertible {
     
     var description: String {
         return "(\(id)), X:\(point.X),Y:\(point.Y), W\(size.Width), H\(size.Height), R:\(R), G:\(G), B:\(B), alpha: \(alpha)"
+    }
+}
+
+extension Square: Equatable {
+    public static func ==(lhs: Square, rhs: Square) -> Bool {
+        return lhs.id == rhs.id
     }
 }

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -2,27 +2,85 @@ import UIKit
 import OSLog
 
 class ViewController: UIViewController {
+
     let factory: SquareFactory = SquareFactory()
+    
+    var plane: Plane = Plane()
+    
+    var selectedSquare: Square?
+
+    private let imageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        self.view.addSubview(self.imageView)
+        
+        NSLayoutConstraint.activate([
+            self.imageView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            self.imageView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            self.imageView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            self.imageView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+        ])
 
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView(_:)))
         
         self.view.addGestureRecognizer(recognizer)
         
-        var squareAry : [Square] = []
-        
         for i in 1..<5 {
-            squareAry.append(factory.createSquare(size: Size(width: Double(i * 100), height: Double(i * 200)), point: Point(X: Double(i * 300), Y: Double(i * 400)), R: UInt8(i + 10), G: UInt8(i + 20), B: UInt8(i + 30), alpha: 2 * i + 1))
+            self.plane.addSquare(square: factory.createSquare(size: Size(width: Double(i * 50), height: Double(i * 100)), point: Point(X: Double(i * 200), Y: Double(i * 50)), R: UInt8(Int.random(in: 0..<255)), G: UInt8(Int.random(in: 0..<255)), B: UInt8(Int.random(in: 0..<255)), alpha: 10))
         }
         
         for i in 0..<4 {
-            os_log("Rect%@ %@", "\(i)", "\(squareAry[i])")
+            os_log("Rect%@ %@", "\(i)", "\(self.plane[i])")
         }
+        
+        self.drawPlane()
     }
 
     @objc func didTapView(_ sender: UITapGestureRecognizer) {
-        print("did tap: ", sender.location(in: self.view))
+        let point = Point(X: sender.location(in: self.view).x, Y: sender.location(in: self.view).y)
+        self.selectedSquare = self.plane[point]
+
+        drawPlane()
+    }
+}
+
+extension ViewController {
+    func drawPlane() {
+        UIGraphicsBeginImageContext(self.view.frame.size)
+        let context = UIGraphicsGetCurrentContext()!
+        context.setLineWidth(2.0)
+        context.setStrokeColor(UIColor.systemBlue.cgColor)
+        
+        for s in self.plane.square {
+            context.setFillColor(red: CGFloat(s.R)/255.0, green: CGFloat(s.G)/255.0, blue: CGFloat(s.B)/255.0, alpha: CGFloat(s.alpha)/10.0)
+            
+            let x = s.point.X
+            let y = s.point.Y
+            let w = s.size.Width
+            let h = s.size.Height
+            
+            context.move(to: CGPoint(x: x, y: y))
+            context.addLine(to: CGPoint(x: x + w, y: y))
+            context.addLine(to: CGPoint(x: x + w, y: y + h))
+            context.addLine(to: CGPoint(x: x, y: y + h))
+            context.addLine(to: CGPoint(x: x, y: y))
+            context.closePath()
+            
+            if s == self.selectedSquare {
+                context.drawPath(using: .fillStroke)
+            } else {
+                context.fillPath()
+            }
+            //context.strokePath()
+        }
+
+        self.imageView.image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
     }
 }


### PR DESCRIPTION
### 작업 목록
- Square 클래스에 Equatable
- Core Graphics를 활용한 사각형 그리는 기능 추가
- 사각형 선택 기능 추가

### 학습 키워드
- `UITapGestureRecognizer`
- `Core Graphics`
- `Equatable`
- `NSLayoutConstraint`

## 고민
1. swift에서 도형 그리는 방법에는 크게 두 가지 방법이 있었다.
    1. 코어 그래픽스
    2. view를 도형처럼 사용
    - 처음에는 view를 도형처럼 사용하는 방법을 사용했다. 코어 그래픽스를 활용해 직접 그리는 것보다 코드가 간단했기 때문이다.
    - 하지만, 별도의 변수를 UIView변수를 두는 방식으로 view를 각 도형마다 연결하여야 했기에, 오히려 구조가 복잡해졌다. 또한, 모델과 UIKit/Core Graphics를 분리할 수 없는 문제도 있었다.
    - 해결: 코어 그래픽스를 사용해 직접 그리는 방식으로 변경하였다.
2. `UIGraphicsGetCurrentContext()`의 반환값을 언박싱하는 과정에서, Fatal error 발생: `Unexpectedly found nil while unwrapping an Optional value`
    - 원인
        - `UIGraphicsGetCurrentContext()`에 nil이 반환되었고, 이후 코드에서는 반환된 CGContext변수를 언박싱하는 로직이 포함되어 있었기에 해당 오류를 반환하였다.
        - view의 subView인 imageView는 크기가 지정되지 않은 상태였기 때문에 `UIGraphicsBeginImageContext()`에서 context가 제대로 생성되지 않았다(높이/너비가 0.0/0.0인 경우에는 context가 생성되지 않는 듯하다).
        - 이미 imageView의 레이아웃을 지정하였기 때문에, width/height을 지정하지 않고 정상적으로 context를 생성하는 방법에 대해 구상했지만, 다른 방
    - 해결: self.view와 imageView의 크기가 같기 때문에, view의 크기를 `UIGraphicsBeginImageContext()`의 매개변수로 넘겨줌으로써 해결
3. ViewController에는 StoryBoard단계에서 view를 미리 넣어주어야 한다. ViewController.swift에서는 넣어줄 방법이 없음
    - 넣어주더라도, width/height를 NSConstraint로 설정하여야 하는데, 이러면 `UIGraphicsGetCurrentContext()`에서 위와 같은 런타임 에러가 발생
4. 화면 크기 구하는 방법
    - UIScreen.main.bounds를 CGRect변수에 저장한 후, width/height 변수를 꺼내면 된다
5. 깨진 모서리 다듬는 방법
    - closePath() 수정자 사용
        - SwiftUI에서는 closeSubpath()가 같은 역할을 수행
6. fill과 stroke함수를 코드에 포함시켜도, 둘 중 하나만 동작하였다
    - 해결: `Context.drawPath()`를 사용하여 테두리 그리기/채우기를 동시에 수행하도록 만들 수 있었다
7. 객체를 비교하기 위해서는 Equatable 프로토콜을 채택하여 == 연산자를 오버로딩하여야 한다
## 질문
- Core Graphics/UIKit에 독립적인 타입으로 구현하여야 하는 이유가 궁금합니다. Model과 Controller를 분리하여도, CGPoint와 같이 사실상 같은 내용을 다루는 자료형에는 사용해도 괜찮겠다는 생각이 들었기 때문입니다. 아니면 또다른 이유가 있을까요?
- imageView에서 widthAnchor/heightAnchor를 설정하였으나, 결국 imageView의 크기는 0.0/0.0인 상태 그대로였습니다. 어째서 `NSLayoutConstraint`설정이 무시되는지 궁금합니다.
- self.view는 Main.storyboard에서 화면을 꽉 채우도록 크기를 설정해놓았기에, `UIGraphicsBeginImageContext()`의 매개변수로 전달할 수 있었습니다. storyboard를 사용하지 않고도 view의 크기를 지정하는 방법이 있을까요?
- 선택된 사각형에 테두리는 그리는 기능을 구현하는 과정에서, ViewController에 별도의 참조 변수를 저장하고, 전체 사각형을 렌더링할 때마다 확인하도록 했습니다. 이 방법과 사각형에 별도의 변수를 두는 것 이외에 또다른 방법이 있을까요?
- Main.storyboard에서 view의 width/height 속성이 뒤바뀐 이유가 궁금합니다. `Refactor: Square 구조 변경` 커밋의 Main.storyboard 변경 항목에 해당 내용이 있습니다.
- ViewController.swift에 StoryBoard에서 넣은 것과 마찬가지 결과를 내도록 main view를 넣어줄 방법은 없을까요?
- `Context.fillPath()`와 `Context.strokePath()`를 같이 넣어놓을 경우, 두 함수의 순서에 따라 둘 중 하나만 동작합니다. 이에 대한 이유가 궁금합니다.
