### PR TITLE
[Ocean] Step2-5: 역할 분리 및 뷰 계층화 다시 적용

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		F5329F6227D9E70700B7706C /* Square.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5329F6127D9E70700B7706C /* Square.swift */; };
 		F5329F6427D9EC8800B7706C /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5329F6327D9EC8800B7706C /* Size.swift */; };
 		F5329F6627D9EC9B00B7706C /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5329F6527D9EC9B00B7706C /* Point.swift */; };
+		F557CCCA285F7C090050C24D /* StatusSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F557CCC9285F7C090050C24D /* StatusSection.swift */; };
+		F5628865285E4B6E0071289E /* DrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5628864285E4B6E0071289E /* DrawingView.swift */; };
 		F56BAD112849F0FA00C607E4 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56BAD102849F0FA00C607E4 /* MainView.swift */; };
 		F56DE4472858E0370085F74D /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56DE4462858E0370085F74D /* UIColorExtension.swift */; };
 		F5C730F427CC7AB8001B4EFF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C730F327CC7AB8001B4EFF /* AppDelegate.swift */; };
@@ -26,6 +28,8 @@
 		F5329F6127D9E70700B7706C /* Square.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Square.swift; sourceTree = "<group>"; };
 		F5329F6327D9EC8800B7706C /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
 		F5329F6527D9EC9B00B7706C /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
+		F557CCC9285F7C090050C24D /* StatusSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusSection.swift; sourceTree = "<group>"; };
+		F5628864285E4B6E0071289E /* DrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingView.swift; sourceTree = "<group>"; };
 		F56BAD102849F0FA00C607E4 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		F56DE4462858E0370085F74D /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		F5C730F027CC7AB8001B4EFF /* DrawingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrawingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -109,6 +113,8 @@
 				F5C730FE27CC7AB8001B4EFF /* LaunchScreen.storyboard */,
 				F5C7310127CC7AB8001B4EFF /* Info.plist */,
 				F56BAD102849F0FA00C607E4 /* MainView.swift */,
+				F5628864285E4B6E0071289E /* DrawingView.swift */,
+				F557CCC9285F7C090050C24D /* StatusSection.swift */,
 			);
 			path = DrawingApp;
 			sourceTree = "<group>";
@@ -226,8 +232,10 @@
 				F5329F6627D9EC9B00B7706C /* Point.swift in Sources */,
 				F5C730F827CC7AB8001B4EFF /* ViewController.swift in Sources */,
 				F5C730F427CC7AB8001B4EFF /* AppDelegate.swift in Sources */,
+				F557CCCA285F7C090050C24D /* StatusSection.swift in Sources */,
 				F5D3D0C027E1A5E200B6DFDF /* Plane.swift in Sources */,
 				F5C730F627CC7AB8001B4EFF /* SceneDelegate.swift in Sources */,
+				F5628865285E4B6E0071289E /* DrawingView.swift in Sources */,
 				F56DE4472858E0370085F74D /* UIColorExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DrawingApp/DrawingApp/DrawingView.swift
+++ b/DrawingApp/DrawingApp/DrawingView.swift
@@ -25,4 +25,8 @@ class DrawingSection: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
+
+    func addSquare(square: UIView) {
+        self.drawingView.addSubview(square)
+    }
 }

--- a/DrawingApp/DrawingApp/DrawingView.swift
+++ b/DrawingApp/DrawingApp/DrawingView.swift
@@ -1,0 +1,28 @@
+import UIKit
+
+class DrawingSection: UIView {
+
+    private let drawingView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .white
+        return view
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.addSubview(drawingView)
+        
+        NSLayoutConstraint.activate([
+            self.drawingView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.drawingView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            self.drawingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            self.drawingView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}

--- a/DrawingApp/DrawingApp/MainView.swift
+++ b/DrawingApp/DrawingApp/MainView.swift
@@ -7,6 +7,6 @@ class MainView: UIView {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
     }
 }

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -1,9 +1,15 @@
 import Foundation
 
 struct Plane {
+
+    let factory: SquareFactory = SquareFactory()
+
     var square: [Square] = []
-    mutating func addSquare(square: Square) {
+
+    mutating func addSquare(frameWidth: Double, frameHeight: Double) -> Square {
+        let square = self.factory.createRandomSquare(frameWidth: frameWidth, frameHeight: frameHeight)
         self.square.append(square)
+        return square
     }
     
     var totalSquareCount: Int {

--- a/DrawingApp/DrawingApp/Model/Square.swift
+++ b/DrawingApp/DrawingApp/Model/Square.swift
@@ -7,7 +7,22 @@ class Square : CustomStringConvertible {
     var R: UInt8
     var G: UInt8
     var B: UInt8
-    var alpha: Int
+    var _alpha: Int = 10
+    var alpha: Int {
+        get {
+            return self._alpha
+        }
+        set {
+            switch newValue {
+            case ...0 :
+                self._alpha = 0
+            case 10...:
+                self._alpha = 10
+            default:
+                self._alpha = newValue
+            }
+        }
+    }
 
     init(id: String, size: Size, point: Point, R: UInt8, G: UInt8, B: UInt8, alpha: Int) {
         self.id = id
@@ -17,14 +32,7 @@ class Square : CustomStringConvertible {
         self.R = R
         self.G = G
         self.B = B
-        switch alpha {
-        case ...0 :
-            self.alpha = 0
-        case 10...:
-            self.alpha = 10
-        default:
-            self.alpha = alpha
-        }
+        self.alpha = alpha
     }
     
     func isPointIncluded(position: Point) -> Bool {

--- a/DrawingApp/DrawingApp/Model/SquareFactory.swift
+++ b/DrawingApp/DrawingApp/Model/SquareFactory.swift
@@ -7,6 +7,18 @@ class SquareFactory {
         return Square(id: getRandomId(), size: size, point: point, R: UInt8(R), G: UInt8(G), B: UInt8(B), alpha: alpha)
     }
     
+    func createRandomSquare(frameWidth: Double, frameHeight: Double) -> Square {
+        var width, height, x, y: Double
+        repeat {
+            width = Double(Int.random(in: 1..<Int(frameWidth)))
+            height = Double(Int.random(in: 1..<Int(frameHeight)))
+            x = Double(Int.random(in: 0..<Int(frameWidth)))
+            y = Double(Int.random(in: 0..<Int(frameHeight)))
+        } while !((x + width < frameWidth) && (y + height < frameHeight))
+
+        return createSquare(size: Size(width: width, height: height), point: Point(X: x, Y: y), R: UInt8(Int.random(in: 0..<255)), G: UInt8(Int.random(in: 0..<255)), B: UInt8(Int.random(in: 0..<255)), alpha: 10)
+    }
+    
     func getRandomId() -> String {
         var id = String((0 ..< 9).map{ _ in idElement.randomElement()! })
         id.insert("-", at: id.index(id.startIndex, offsetBy: 3))

--- a/DrawingApp/DrawingApp/StatusSection.swift
+++ b/DrawingApp/DrawingApp/StatusSection.swift
@@ -1,8 +1,6 @@
 import UIKit
 
 class StatusSection: UIView {
-    
-    var delegate: ViewController?
 
     private let backgroundColorTitle: UILabel = {
         let label = UILabel()
@@ -18,14 +16,14 @@ class StatusSection: UIView {
         return label
     }()
     
-    private let backgroundColorStatus: UIColorWell = {
+    let backgroundColorStatus: UIColorWell = {
         let colorWell = UIColorWell()
         colorWell.translatesAutoresizingMaskIntoConstraints = false
         colorWell.supportsAlpha = false
         return colorWell
     }()
 
-    private let alphaStatus: UIStepper = {
+    let alphaStatus: UIStepper = {
         let stepper = UIStepper()
         stepper.translatesAutoresizingMaskIntoConstraints = false
         stepper.maximumValue = 10
@@ -66,5 +64,16 @@ class StatusSection: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
+    
+    func getAlpha() -> Double {
+        return self.alphaStatus.value
+    }
 
+    func setAlpha(alpha: Double) {
+        self.alphaStatus.value = alpha
+    }
+
+    func getSelectedColor() -> UIColor? {
+        return self.backgroundColorStatus.selectedColor
+    }
 }

--- a/DrawingApp/DrawingApp/StatusSection.swift
+++ b/DrawingApp/DrawingApp/StatusSection.swift
@@ -1,0 +1,70 @@
+import UIKit
+
+class StatusSection: UIView {
+    
+    var delegate: ViewController?
+
+    private let backgroundColorTitle: UILabel = {
+        let label = UILabel()
+        label.text = "배경색"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let alphaTitle: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "투명도"
+        return label
+    }()
+    
+    private let backgroundColorStatus: UIColorWell = {
+        let colorWell = UIColorWell()
+        colorWell.translatesAutoresizingMaskIntoConstraints = false
+        colorWell.supportsAlpha = false
+        return colorWell
+    }()
+
+    private let alphaStatus: UIStepper = {
+        let stepper = UIStepper()
+        stepper.translatesAutoresizingMaskIntoConstraints = false
+        stepper.maximumValue = 10
+        stepper.minimumValue = 0
+        stepper.value = 0
+        stepper.wraps = false
+        stepper.autorepeat = true
+        return stepper
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.addSubview(backgroundColorTitle)
+        self.addSubview(backgroundColorStatus)
+        self.addSubview(alphaTitle)
+        self.addSubview(alphaStatus)
+        
+        NSLayoutConstraint.activate([
+            self.backgroundColorTitle.topAnchor.constraint(equalTo: self.topAnchor),
+            self.backgroundColorTitle.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.backgroundColorTitle.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            
+            self.backgroundColorStatus.topAnchor.constraint(equalTo: self.backgroundColorTitle.bottomAnchor),
+            self.backgroundColorStatus.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.backgroundColorStatus.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            
+            self.alphaTitle.topAnchor.constraint(equalTo: self.backgroundColorStatus.bottomAnchor),
+            self.alphaTitle.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.alphaTitle.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            
+            self.alphaStatus.topAnchor.constraint(equalTo: self.alphaTitle.bottomAnchor),
+            self.alphaStatus.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.alphaStatus.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+}

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -22,57 +22,9 @@ class ViewController: UIViewController {
         let section = StatusSection()
         section.translatesAutoresizingMaskIntoConstraints = false
         section.backgroundColor = .systemGray4
+        section.backgroundColorStatus.addTarget(self, action: #selector(colorChanged(_:)), for: .valueChanged)
+        section.alphaStatus.addTarget(self, action: #selector(stepperValueChanged(_:)), for: .valueChanged)
         return section
-    }()
-
-    private let drawingView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
-        return view
-    }()
-
-    private let statusView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .systemGray4
-        return view
-    }()
-    
-    private let backgroundTitle: UILabel = {
-        let label = UILabel()
-        label.text = "배경색"
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    private let alphaTitle: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "투명도"
-        return label
-    }()
-    
-    private let backgroundColorStatus: UIColorWell = {
-        let colorWell = UIColorWell()
-        colorWell.translatesAutoresizingMaskIntoConstraints = false
-        colorWell.supportsAlpha = false
-        colorWell.addTarget(ViewController.self, action: #selector(colorChanged(_:)), for: .valueChanged)
-        
-        return colorWell
-    }()
-
-    private let alphaStatus: UIStepper = {
-        let stepper = UIStepper()
-        stepper.translatesAutoresizingMaskIntoConstraints = false
-        stepper.maximumValue = 10
-        stepper.minimumValue = 0
-        stepper.value = 0
-        stepper.wraps = false
-        stepper.autorepeat = true
-        stepper.addTarget(ViewController.self, action: #selector(stepperValueChanged(_:)), for: .valueChanged)
-        
-        return stepper
     }()
     
     override func loadView() {
@@ -80,7 +32,7 @@ class ViewController: UIViewController {
         
         let tapGestureRecognizer = UITapGestureRecognizer()
         tapGestureRecognizer.delegate = self
-        self.drawingView.addGestureRecognizer(tapGestureRecognizer)
+        self.drawingSection.addGestureRecognizer(tapGestureRecognizer)
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -89,54 +41,32 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        self.statusSection.delegate = self
         
-        self.view.addSubview(self.drawingView)
-        self.view.addSubview(self.statusView)
-        self.view.addSubview(self.backgroundTitle)
-        self.view.addSubview(self.backgroundColorStatus)
-        self.view.addSubview(self.alphaTitle)
-        self.view.addSubview(self.alphaStatus)
+        self.view.addSubview(self.drawingSection)
+        self.view.addSubview(self.statusSection)
         
         let safeArea = view.safeAreaLayoutGuide
         
         NSLayoutConstraint.activate([
-            self.drawingView.topAnchor.constraint(equalTo: safeArea.topAnchor),
-            self.drawingView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
-            self.drawingView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            self.drawingView.trailingAnchor.constraint(equalTo: self.statusView.leadingAnchor),
+            self.drawingSection.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            self.drawingSection.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+            self.drawingSection.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            self.drawingSection.trailingAnchor.constraint(equalTo: self.statusSection.leadingAnchor),
             
-            self.statusView.widthAnchor.constraint(equalToConstant: 300),
-            self.statusView.topAnchor.constraint(equalTo: safeArea.topAnchor),
-            self.statusView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
-            self.statusView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            
-            self.backgroundTitle.topAnchor.constraint(equalTo: self.statusView.topAnchor),
-            self.backgroundTitle.leadingAnchor.constraint(equalTo: self.statusView.leadingAnchor),
-            self.backgroundTitle.trailingAnchor.constraint(equalTo: self.statusView.trailingAnchor),
-            
-            self.backgroundColorStatus.topAnchor.constraint(equalTo: self.backgroundTitle.bottomAnchor),
-            self.backgroundColorStatus.leadingAnchor.constraint(equalTo: self.statusView.leadingAnchor),
-            self.backgroundColorStatus.trailingAnchor.constraint(equalTo: self.statusView.trailingAnchor),
-            
-            self.alphaTitle.topAnchor.constraint(equalTo: self.backgroundColorStatus.bottomAnchor),
-            self.alphaTitle.leadingAnchor.constraint(equalTo: self.statusView.leadingAnchor),
-            self.alphaTitle.trailingAnchor.constraint(equalTo: self.statusView.trailingAnchor),
-            
-            self.alphaStatus.topAnchor.constraint(equalTo: self.alphaTitle.bottomAnchor),
-            self.alphaStatus.leadingAnchor.constraint(equalTo: self.statusView.leadingAnchor),
-            self.alphaStatus.trailingAnchor.constraint(equalTo: self.statusView.trailingAnchor)
+            self.statusSection.widthAnchor.constraint(equalToConstant: 300),
+            self.statusSection.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            self.statusSection.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+            self.statusSection.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
         ])
     }
     
     override func viewDidAppear(_ animated: Bool) {
         for _ in 0..<4 {
-            let square = plane.addSquare(frameWidth: self.view.safeAreaLayoutGuide.layoutFrame.width - self.statusView.frame.width, frameHeight: self.view.safeAreaLayoutGuide.layoutFrame.height)
+            let square = plane.addSquare(frameWidth: self.view.safeAreaLayoutGuide.layoutFrame.width - self.statusSection.frame.width, frameHeight: self.view.safeAreaLayoutGuide.layoutFrame.height)
             let squareView = UIView(frame: CGRect(x: square.point.X, y: square.point.Y, width: square.size.Width, height: square.size.Height))
             squareView.backgroundColor = UIColor(red: CGFloat(square.R)/255, green: CGFloat(square.G)/255, blue: CGFloat(square.B)/255, alpha: CGFloat(square.alpha)/10)
             self.planeViews[square] = squareView
-            self.drawingView.addSubview(squareView)
+            self.drawingSection.addSquare(square: squareView)
         }
         
         for i in 0..<4 {
@@ -148,7 +78,7 @@ class ViewController: UIViewController {
 
 extension ViewController: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        let CGPosition = touch.location(in: self.drawingView)
+        let CGPosition = touch.location(in: self.drawingSection)
 
         if selectedSquare != nil {
             self.planeViews[selectedSquare!]!.layer.borderWidth = CGFloat(0.0)
@@ -164,7 +94,7 @@ extension ViewController: UIGestureRecognizerDelegate {
         
         squareView.layer.borderWidth = CGFloat(5.0)
         squareView.layer.borderColor = CGColor(red: 0.0, green: 0.0, blue: 1.0, alpha: 1.0)
-        self.alphaStatus.value = (squareView.backgroundColor?.cgColor.alpha)! * 10
+        self.statusSection.setAlpha(alpha: (squareView.backgroundColor?.cgColor.alpha)! * 10)
 
         return true
     }
@@ -176,16 +106,16 @@ extension ViewController: UIGestureRecognizerDelegate {
             let r = color.red
             let g = color.green
             let b = color.blue
-            squareView.backgroundColor = UIColor(red: r, green: g, blue: b, alpha: alphaStatus.value / 10.0)
-            square.alpha = Int(alphaStatus.value)
+            squareView.backgroundColor = UIColor(red: r, green: g, blue: b, alpha: statusSection.getAlpha() / 10.0)
+            square.alpha = Int(statusSection.getAlpha())
         }
     }
     
     @objc func colorChanged(_ sender: UIColorWell) {
         if let square = self.selectedSquare {
             let squareView = planeViews[square]!
-            squareView.backgroundColor = self.backgroundColorStatus.selectedColor
-            let color = self.backgroundColorStatus.selectedColor!.rgbFloat
+            squareView.backgroundColor = self.statusSection.getSelectedColor()
+            let color = self.statusSection.getSelectedColor()!.rgbFloat
             square.R = UInt8(color.red * 255.0)
             square.G = UInt8(color.green * 255.0)
             square.B = UInt8(color.blue * 255.0)

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -79,14 +79,16 @@ class ViewController: UIViewController {
         self.view.addSubview(self.alphaTitle)
         self.view.addSubview(self.alphaStatus)
         
+        let guide = view.safeAreaLayoutGuide
+        
         NSLayoutConstraint.activate([
-            self.drawingView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            self.drawingView.topAnchor.constraint(equalTo: guide.topAnchor),
             self.drawingView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
             self.drawingView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             self.drawingView.trailingAnchor.constraint(equalTo: self.statusView.leadingAnchor),
             
             self.statusView.widthAnchor.constraint(equalToConstant: 300),
-            self.statusView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            self.statusView.topAnchor.constraint(equalTo: guide.topAnchor),
             self.statusView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
             self.statusView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
             

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -83,17 +83,17 @@ class ViewController: UIViewController {
         self.view.addSubview(self.alphaTitle)
         self.view.addSubview(self.alphaStatus)
         
-        let guide = view.safeAreaLayoutGuide
+        let safeArea = view.safeAreaLayoutGuide
         
         NSLayoutConstraint.activate([
-            self.drawingView.topAnchor.constraint(equalTo: guide.topAnchor),
-            self.drawingView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            self.drawingView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            self.drawingView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
             self.drawingView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             self.drawingView.trailingAnchor.constraint(equalTo: self.statusView.leadingAnchor),
             
             self.statusView.widthAnchor.constraint(equalToConstant: 300),
-            self.statusView.topAnchor.constraint(equalTo: guide.topAnchor),
-            self.statusView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            self.statusView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            self.statusView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
             self.statusView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
             
             self.backgroundTitle.topAnchor.constraint(equalTo: self.statusView.topAnchor),
@@ -112,31 +112,15 @@ class ViewController: UIViewController {
             self.alphaStatus.leadingAnchor.constraint(equalTo: self.statusView.leadingAnchor),
             self.alphaStatus.trailingAnchor.constraint(equalTo: self.statusView.trailingAnchor)
         ])
-        
-        self.view.layoutIfNeeded()
-        
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
         for _ in 0..<4 {
-            let frameWidth = self.drawingView.frame.width
-            let frameHeight = self.drawingView.frame.height
-            var width, height, x, y: Double
-            var r, g, b: Int
-
-            repeat {
-                width = Double(Int.random(in: 1..<Int(frameWidth)))
-                height = Double(Int.random(in: 1..<Int(frameHeight)))
-                x = Double(Int.random(in: 0..<Int(frameWidth)))
-                y = Double(Int.random(in: 0..<Int(frameHeight)))
-            } while !((x + width < Double(frameWidth)) && (y + height < Double(frameHeight)))
-            
-            r = Int.random(in: 0..<255)
-            g = Int.random(in: 0..<255)
-            b = Int.random(in: 0..<255)
-            let square = factory.createSquare(size: Size(width: width, height: height), point: Point(X: x, Y: y), R: UInt8(r), G: UInt8(g), B: UInt8(b), alpha: 10)
-            let squareView = UIView(frame: CGRect(x: x, y: y, width: width, height: height))
-            squareView.backgroundColor = UIColor(red: CGFloat(r)/255, green: CGFloat(g)/255, blue: CGFloat(b)/255, alpha: 10/10)
+            let square = plane.addSquare(frameWidth: self.view.safeAreaLayoutGuide.layoutFrame.width - self.statusView.frame.width, frameHeight: self.view.safeAreaLayoutGuide.layoutFrame.height)
+            let squareView = UIView(frame: CGRect(x: square.point.X, y: square.point.Y, width: square.size.Width, height: square.size.Height))
+            squareView.backgroundColor = UIColor(red: CGFloat(square.R)/255, green: CGFloat(square.G)/255, blue: CGFloat(square.B)/255, alpha: CGFloat(square.alpha)/10)
             self.planeViews[square] = squareView
             self.drawingView.addSubview(squareView)
-            self.plane.addSquare(square: square)
         }
         
         for i in 0..<4 {

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -68,6 +68,10 @@ class ViewController: UIViewController {
         tapGestureRecognizer.delegate = self
         self.drawingView.addGestureRecognizer(tapGestureRecognizer)
     }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -113,9 +113,11 @@ class ViewController: UIViewController {
             self.alphaStatus.trailingAnchor.constraint(equalTo: self.statusView.trailingAnchor)
         ])
         
+        self.view.layoutIfNeeded()
+        
         for _ in 0..<4 {
-            let frameWidth = self.view.frame.width - 300
-            let frameHeight = self.view.frame.height
+            let frameWidth = self.drawingView.frame.width
+            let frameHeight = self.drawingView.frame.height
             var width, height, x, y: Double
             var r, g, b: Int
 

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -10,6 +10,20 @@ class ViewController: UIViewController {
     var planeViews: [Square: UIView] = [:]
     
     private var selectedSquare: Square?
+    
+    private let drawingSection: DrawingSection = {
+        let section = DrawingSection()
+        section.translatesAutoresizingMaskIntoConstraints = false
+        section.backgroundColor = .white
+        return section
+    }()
+    
+    private let statusSection: StatusSection = {
+        let section = StatusSection()
+        section.translatesAutoresizingMaskIntoConstraints = false
+        section.backgroundColor = .systemGray4
+        return section
+    }()
 
     private let drawingView: UIView = {
         let view = UIView()
@@ -43,7 +57,7 @@ class ViewController: UIViewController {
         let colorWell = UIColorWell()
         colorWell.translatesAutoresizingMaskIntoConstraints = false
         colorWell.supportsAlpha = false
-        colorWell.addTarget(self, action: #selector(colorChanged(_:)), for: .valueChanged)
+        colorWell.addTarget(ViewController.self, action: #selector(colorChanged(_:)), for: .valueChanged)
         
         return colorWell
     }()
@@ -56,7 +70,7 @@ class ViewController: UIViewController {
         stepper.value = 0
         stepper.wraps = false
         stepper.autorepeat = true
-        stepper.addTarget(self, action: #selector(stepperValueChanged(_:)), for: .valueChanged)
+        stepper.addTarget(ViewController.self, action: #selector(stepperValueChanged(_:)), for: .valueChanged)
         
         return stepper
     }()
@@ -76,6 +90,8 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        self.statusSection.delegate = self
+        
         self.view.addSubview(self.drawingView)
         self.view.addSubview(self.statusView)
         self.view.addSubview(self.backgroundTitle)


### PR DESCRIPTION
### 작업 목록
- ViewController에서 Plane과 중복되는 역할을 Plane으로 이동
  - 무작위 사각형 생성 및 Plane 모델에 추가하는 기능
- 뷰 계층 구조 다시 적용(DrawingSection/StatusSection)
- SafeArea 적용

### 학습 키워드
- `SafeArea`
- `MVC`
- `get/set`
- `required init()`

## 고민
1. 제스처 인식기에서, 터치하는 영역을 인식하는 방법으로 HitTest가 필요하지 않음을 알게 되었다. addGestureRecognizer()에서 영역을 제한해줌으로써 구별이 가능했고, 이를 멤버들의 피드백 덕분에 알게 되어 고칠 수 있었다.
2. SafeArea의 frame값을 사각형의 생성 범위를 지정하고 싶었는데, 전체 화면의 frame과 똑같은 (1180,820)을 반환하였다. 이후, 사각형의 범위를 대입하는 로직을 viewDidLoad()가 아닌 viewDidAppear()로 옮김으로써, 오토 레이아웃이 적용된 frame값을 전달할 수 있었다.
3. ViewController에서 사각형 모델을 생성하는 로직을 가지고 있었는데, 이는 Plane과 SquareFactory이 이미 가지고 있는 기능이었다. 따라서, SquareFactory를 Plane으로 옮김으로써, Plane이 모델을 생성하는 역할을 맡도록 하였다.
